### PR TITLE
fix: User 엔티티 테이블명 예약어 오류 해결

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/user/entity/User.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/entity/User.java
@@ -11,7 +11,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user")
+@Table(name = "`user`")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {


### PR DESCRIPTION
## 작업 내용
- User 엔티티의 @Table 어노테이션에 백틱 추가
- MySQL user 예약어 충돌 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of user account operations in specific database environments, reducing edge-case errors when accessing user data.

* **Chores**
  * Internal database mapping adjustment for the user entity to improve compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->