### PR TITLE
feat: screentime 등록 api 구현

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/common/dto/ResponseDto.java
+++ b/src/main/java/org/minu/dnd13th3backend/common/dto/ResponseDto.java
@@ -9,19 +9,16 @@ public class ResponseDto<T> {
 
     private final boolean success;
     private final String message;
-    private final T data; // 제네릭(Generic) 타입 T를 사용하여 어떤 종류의 데이터든 담을 수 있음
+    private final T data;
 
-    // 성공 시 사용할 정적 팩토리 메서드
     public static <T> ResponseDto<T> success(String message, T data) {
         return new ResponseDto<>(true, message, data);
     }
 
-    // 성공했지만 데이터가 없을 경우
     public static <T> ResponseDto<T> success(String message) {
         return new ResponseDto<>(true, message, null);
     }
 
-    // 실패 시 사용할 정적 팩토리 메서드
     public static <T> ResponseDto<T> fail(String message) {
         return new ResponseDto<>(false, message, null);
     }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/controller/ScreenTimeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/controller/ScreenTimeController.java
@@ -1,4 +1,35 @@
 package org.minu.dnd13th3backend.screentime.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.minu.dnd13th3backend.common.dto.ResponseDto;
+import org.minu.dnd13th3backend.screentime.dto.request.ScreenTimePostRequest;
+import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimePostResponse;
+import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
+import org.minu.dnd13th3backend.screentime.service.ScreenTimeService;
+import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/screentime")
+@RequiredArgsConstructor
 public class ScreenTimeController {
+
+    private final ScreenTimeService screenTimeService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDto<ScreenTimePostResponse>> registerScreenTime(
+            @RequestBody ScreenTimePostRequest requestDto,
+            @AuthenticationPrincipal User user
+    ) {
+        ScreenTime screenTime = screenTimeService.registerOrUpdateScreenTime(requestDto, user);
+
+        ScreenTimePostResponse response = new ScreenTimePostResponse(screenTime);
+
+        return ResponseEntity.ok(ResponseDto.success("스크린타임이 성공적으로 등록/갱신되었습니다.", response));
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/request/ScreenTimePostRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/request/ScreenTimePostRequest.java
@@ -1,4 +1,15 @@
 package org.minu.dnd13th3backend.screentime.dto.request;
 
-public class ScreenTimePOSTRequest {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScreenTimePostRequest {
+    private LocalDate date;
+    private Integer screentimeMinutes;
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimePostResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimePostResponse.java
@@ -1,4 +1,20 @@
 package org.minu.dnd13th3backend.screentime.dto.response;
 
+import lombok.Getter;
+import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
+
+import java.time.LocalDate;
+
+@Getter
 public class ScreenTimePostResponse {
+
+    private final Long id;
+    private final LocalDate date;
+    private final Integer screentimeMinutes; // screentime_minutes -> screentimeMinutes
+
+    public ScreenTimePostResponse(ScreenTime screenTime) {
+        this.id = screenTime.getId();
+        this.date = screenTime.getDate();
+        this.screentimeMinutes = screenTime.getScreentimeMinutes();
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/entity/ScreenTime.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/entity/ScreenTime.java
@@ -1,4 +1,38 @@
 package org.minu.dnd13th3backend.screentime.entity;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.minu.dnd13th3backend.user.entity.User;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ScreenTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private LocalDate date;
+    private Integer screentimeMinutes;
+
+    @Builder
+    public ScreenTime(User user, LocalDate date, Integer screentimeMinutes) {
+        this.user = user;
+        this.date = date;
+        this.screentimeMinutes = screentimeMinutes;
+    }
+
+    public void updateScreenTime(Integer minutes) {
+        this.screentimeMinutes = minutes;
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/repository/ScreenTimeRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/repository/ScreenTimeRepository.java
@@ -1,4 +1,13 @@
 package org.minu.dnd13th3backend.screentime.repository;
 
-public class ScreenTimeRepository {
+import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
+import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface ScreenTimeRepository extends JpaRepository<ScreenTime, Long> {
+
+    Optional<ScreenTime> findByUserAndDate(User user, LocalDate date);
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -1,4 +1,36 @@
-package org.minu.dnd13th3backend.challenge.service;
+package org.minu.dnd13th3backend.screentime.service;
 
-public class ChallengeService {
+import lombok.RequiredArgsConstructor;
+import org.minu.dnd13th3backend.screentime.dto.request.ScreenTimePostRequest; // 경로 수정
+import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
+import org.minu.dnd13th3backend.screentime.repository.ScreenTimeRepository;
+import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ScreenTimeService {
+
+    private final ScreenTimeRepository screenTimeRepository;
+
+    @Transactional
+    public ScreenTime registerOrUpdateScreenTime(ScreenTimePostRequest requestDto, User user) {
+        Optional<ScreenTime> optionalScreenTime = screenTimeRepository.findByUserAndDate(user, requestDto.getDate());
+
+        if (optionalScreenTime.isPresent()) {
+            ScreenTime screenTime = optionalScreenTime.get();
+            screenTime.updateScreenTime(requestDto.getScreentimeMinutes());
+            return screenTime;
+        } else {
+            ScreenTime newScreenTime = ScreenTime.builder()
+                    .user(user)
+                    .date(requestDto.getDate())
+                    .screentimeMinutes(requestDto.getScreentimeMinutes())
+                    .build();
+            return screenTimeRepository.save(newScreenTime);
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+    defer-datasource-initialization: true
 
   # OAuth2 Google 설정
   security:


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- screentime 등록 api 구현
- 공통 response 형식 선언
- application.yml 일부 수정

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a screen time submission API for authenticated users to create or update daily screen time, returning a success message with id, date, and minutes.
- Refactor
  - Streamlined internal data access for screen time storage and retrieval.
- Style
  - Removed non-functional comments in a shared response wrapper.
- Chores
  - Adjusted database initialization timing to improve startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->