### PR TITLE
feat: 일/주 단위 스크린타임 조회 구현

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/screentime/controller/ScreenTimeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/controller/ScreenTimeController.java
@@ -7,12 +7,12 @@ import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimePostResponse;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
 import org.minu.dnd13th3backend.screentime.service.ScreenTimeService;
 import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/screentime")
@@ -31,5 +31,15 @@ public class ScreenTimeController {
         ScreenTimePostResponse response = new ScreenTimePostResponse(screenTime);
 
         return ResponseEntity.ok(ResponseDto.success("스크린타임이 성공적으로 등록/갱신되었습니다.", response));
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<?>> getScreenTime(
+            @RequestParam(name = "period") String period,
+            @RequestParam(name = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @AuthenticationPrincipal User user
+    ) {
+        Object responseData = screenTimeService.getScreenTime(period, date, user);
+        return ResponseEntity.ok(ResponseDto.success("스크린타임 조회가 성공했습니다.", responseData));
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetDailyResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetDailyResponse.java
@@ -1,0 +1,41 @@
+package org.minu.dnd13th3backend.screentime.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ScreenTimeGetDailyResponse {
+
+    private List<ScreenTimeData> screenTimes;
+
+    public static ScreenTimeGetDailyResponse from(ScreenTime screenTime) {
+        if (screenTime == null) {
+            return ScreenTimeGetDailyResponse.builder()
+                    .screenTimes(List.of())
+                    .build();
+        }
+        List<ScreenTimeData> data = List.of(new ScreenTimeData(screenTime));
+        return ScreenTimeGetDailyResponse.builder()
+                .screenTimes(data)
+                .build();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ScreenTimeData {
+        private LocalDate date;
+        private int screentimeMinutes;
+
+        public ScreenTimeData(ScreenTime screenTime) {
+            this.date = screenTime.getDate();
+            this.screentimeMinutes = screenTime.getScreentimeMinutes();
+        }
+    }
+}

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetWeeklyResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetWeeklyResponse.java
@@ -1,0 +1,39 @@
+package org.minu.dnd13th3backend.screentime.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class ScreenTimeGetWeeklyResponse {
+
+    private String period;
+
+    @JsonProperty("start_date")
+    private LocalDate startDate;
+
+    @JsonProperty("end_date")
+    private LocalDate endDate;
+
+    @JsonProperty("total_minutes")
+    private int totalMinutes;
+
+    @JsonProperty("average_minutes")
+    private double averageMinutes;
+
+    @JsonProperty("daily_records")
+    private List<DailyRecord> dailyRecords;
+
+    @Getter
+    @Builder
+    public static class DailyRecord {
+        private LocalDate date;
+
+        @JsonProperty("screentime_minutes")
+        private int screentimeMinutes;
+    }
+}

--- a/src/main/java/org/minu/dnd13th3backend/screentime/repository/ScreenTimeRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/repository/ScreenTimeRepository.java
@@ -5,9 +5,14 @@ import org.minu.dnd13th3backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface ScreenTimeRepository extends JpaRepository<ScreenTime, Long> {
 
     Optional<ScreenTime> findByUserAndDate(User user, LocalDate date);
+
+    Optional<ScreenTime> findByUser_IdAndDate(Long userId, LocalDate date);
+
+    List<ScreenTime> findByUser_IdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -1,14 +1,22 @@
 package org.minu.dnd13th3backend.screentime.service;
 
 import lombok.RequiredArgsConstructor;
-import org.minu.dnd13th3backend.screentime.dto.request.ScreenTimePostRequest; // 경로 수정
+import org.minu.dnd13th3backend.screentime.dto.request.ScreenTimePostRequest;
+import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimeGetDailyResponse; // DTO import 이름 변경
+import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimeGetWeeklyResponse;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
 import org.minu.dnd13th3backend.screentime.repository.ScreenTimeRepository;
 import org.minu.dnd13th3backend.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +26,7 @@ public class ScreenTimeService {
 
     @Transactional
     public ScreenTime registerOrUpdateScreenTime(ScreenTimePostRequest requestDto, User user) {
-        Optional<ScreenTime> optionalScreenTime = screenTimeRepository.findByUserAndDate(user, requestDto.getDate());
+        Optional<ScreenTime> optionalScreenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), requestDto.getDate());
 
         if (optionalScreenTime.isPresent()) {
             ScreenTime screenTime = optionalScreenTime.get();
@@ -32,5 +40,56 @@ public class ScreenTimeService {
                     .build();
             return screenTimeRepository.save(newScreenTime);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Object getScreenTime(String period, LocalDate date, User user) {
+        if ("day".equalsIgnoreCase(period)) {
+            return getDailyScreenTime(date, user);
+        } else if ("week".equalsIgnoreCase(period)) {
+            return getWeeklyScreenTime(date, user);
+        } else {
+            throw new IllegalArgumentException("Invalid period value. It must be 'day' or 'week'.");
+        }
+    }
+
+    private ScreenTimeGetDailyResponse getDailyScreenTime(LocalDate date, User user) {
+        LocalDate targetDate = (date == null) ? LocalDate.now() : date;
+        ScreenTime screenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), targetDate)
+                .orElse(null);
+
+        return ScreenTimeGetDailyResponse.from(screenTime);
+    }
+
+    private ScreenTimeGetWeeklyResponse getWeeklyScreenTime(LocalDate date, User user) {
+        LocalDate today = (date == null) ? LocalDate.now() : date;
+        LocalDate startOfWeek = today.with(DayOfWeek.MONDAY);
+        LocalDate endOfWeek = today.with(DayOfWeek.SUNDAY);
+
+        List<ScreenTime> recordedTimes = screenTimeRepository.findByUser_IdAndDateBetween(user.getId(), startOfWeek, endOfWeek);
+
+        Map<LocalDate, Integer> recordedMap = recordedTimes.stream()
+                .collect(Collectors.toMap(ScreenTime::getDate, ScreenTime::getScreentimeMinutes));
+
+        List<ScreenTimeGetWeeklyResponse.DailyRecord> dailyRecords = new ArrayList<>();
+        for (LocalDate d = startOfWeek; !d.isAfter(endOfWeek); d = d.plusDays(1)) {
+            int minutes = recordedMap.getOrDefault(d, 0);
+            dailyRecords.add(ScreenTimeGetWeeklyResponse.DailyRecord.builder()
+                    .date(d)
+                    .screentimeMinutes(minutes)
+                    .build());
+        }
+
+        int totalMinutes = dailyRecords.stream().mapToInt(ScreenTimeGetWeeklyResponse.DailyRecord::getScreentimeMinutes).sum();
+        double averageMinutes = (double) totalMinutes / 7.0;
+
+        return ScreenTimeGetWeeklyResponse.builder()
+                .period("week")
+                .startDate(startOfWeek)
+                .endDate(endOfWeek)
+                .totalMinutes(totalMinutes)
+                .averageMinutes(averageMinutes)
+                .dailyRecords(dailyRecords)
+                .build();
     }
 }


### PR DESCRIPTION
## 관련 이슈
#42 

## 작업 내용
- 일/주 단위 스크린 타임 조회 구현

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GET /api/screentime to retrieve screen time by period.
  * Supports period=daily or weekly, with an optional ISO date parameter (defaults to today).
  * Daily response returns the selected date and total minutes.
  * Weekly response includes start/end dates, total minutes, average minutes, and a daily breakdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->