### PR TITLE
chore: 배포 및 로컬 yml 파일 분기화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-jar", "--spring.profiles.active=prod", "/app/app.jar"]

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,7 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: "http://localhost:8080/login/oauth2/code/google"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,7 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: "https://minu.site/login/oauth2/code/google"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,6 @@ spring:
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: profile,email,https://www.googleapis.com/auth/youtube.readonly
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
 # 서버 포트 설정
 server:


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 기존 application.yml의 redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}" 부분에서 배포 환경에서의 도메인을 추측하지 못하는 문제 발생

- application.yml 공통 설정 및 배포용(application-prod.yml), 로컬용(application-local.yml) 분기 처리

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Google login by using correct redirect URLs in local and production environments.

* **Chores**
  * Container now starts with the production profile enabled.
  * Introduced environment-specific OAuth settings for cleaner separation.
  * Leveraged default redirect behavior where appropriate to simplify configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->