### PR TITLE
fix: OAuth 리다이렉트 URL 환경별 분기처리

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/auth/controller/AuthController.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import org.minu.dnd13th3backend.auth.dto.TokenResponse;
 import org.minu.dnd13th3backend.auth.service.AuthService;
 import org.minu.dnd13th3backend.auth.service.RefreshTokenService;
 import org.minu.dnd13th3backend.auth.service.TokenBlacklistService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -28,15 +29,19 @@ public class AuthController {
     private final AuthService authService;
     private final RefreshTokenService refreshTokenService;
     private final TokenBlacklistService tokenBlacklistService;
+    
+    @Value("${app.frontend.base-url}")
+    private String frontendBaseUrl;
 
     @Operation(hidden = true)
     @GetMapping("/oauth2/success")  
     public RedirectView oauth2Success(@AuthenticationPrincipal OAuth2User oauth2User) {
         TokenResponse tokenResponse = authService.processOAuth2Login(oauth2User);
         
-        String frontendUrl = "http://localhost:3000/login/success" +
+        String frontendUrl = frontendBaseUrl + "/login/success" +
                 "?accessToken=" + tokenResponse.getAccessToken() +
-                "&refreshToken=" + tokenResponse.getRefreshToken();
+                "&refreshToken=" + tokenResponse.getRefreshToken() +
+                "&characterIndex=" + tokenResponse.getCharacterIndex();
         
         return new RedirectView(frontendUrl);
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,3 +5,7 @@ spring:
         registration:
           google:
             redirect-uri: "http://localhost:8080/login/oauth2/code/google"
+
+app:
+  frontend:
+    base-url: http://localhost:3000

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,7 +1,15 @@
 spring:
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: validate
   security:
     oauth2:
       client:
         registration:
           google:
             redirect-uri: "https://minu.site/login/oauth2/code/google"
+
+app:
+  frontend:
+    base-url: ${FRONTEND_BASE_URL}


### PR DESCRIPTION
## 관련 이슈
#64 

## 작업 내용
- AuthController 수정: 하드코딩된 http://localhost:3000 URL을 @Value로 프로퍼티 주입 방식으로 변경
- application-local.yml: 로컬 개발환경용 프론트엔드 URL 설정
- application-prod.yml: 운영환경용 ${FRONTEND_BASE_URL} 환경변수 설정


## 리뷰 요구사항(Optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - OAuth login now redirects to the correct frontend domain per environment.
  - Post-login redirect includes a characterIndex parameter for smoother navigation.
- Chores
  - Added environment-based configuration for the frontend URL.
  - Updated production settings to validate database schema on startup and reduce SQL logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->