### PR TITLE
add: user_id를 통한 nickname 조회 메서드 추가

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.controller;
+
+public class ChallengeController {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/ChallengeCreateRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/ChallengeCreateRequest.java
@@ -1,0 +1,26 @@
+package org.minu.dnd13th3backend.challenge.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.minu.dnd13th3backend.challenge.type.ChallengeType;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeCreateRequest {
+
+    @JsonProperty("start_date")
+    private LocalDate startDate;
+
+    @JsonProperty("end_date")
+    private LocalDate endDate;
+
+    @JsonProperty("goal_time_minutes")
+    private int goalTimeMinutes;
+
+    private ChallengeType type;
+
+    private String title;
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeCreateResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeCreateResponse.java
@@ -1,0 +1,15 @@
+package org.minu.dnd13th3backend.challenge.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class ChallengeCreateResponse {
+
+    @JsonProperty("challenge_id")
+    private final Long challengeId;
+
+    public ChallengeCreateResponse(Long challengeId) {
+        this.challengeId = challengeId;
+    }
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeGetResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeGetResponse.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.dto.response;
+
+public class ChallengeGetResponse {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/entity/Challenge.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/entity/Challenge.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.entity;
+
+public class Challenge {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/entity/ChallengeParticipant.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/entity/ChallengeParticipant.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.entity;
+
+public class ChallengeParticipant {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/entity/InviteCode.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/entity/InviteCode.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.entity;
+
+public class InviteCode {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.repository;
+
+public class ChallengeParticipantRepository {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeRepository.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.repository;
+
+public class ChallengeRepository {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.service;
+
+public class ChallengeService {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeStatus.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeStatus.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.type;
+
+public class ChallengeStatus {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeType.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeType.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.type;
+
+public class ChallengeType {
+}

--- a/src/main/java/org/minu/dnd13th3backend/screentime/controller/ScreenTimeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/controller/ScreenTimeController.java
@@ -2,8 +2,7 @@ package org.minu.dnd13th3backend.screentime.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.minu.dnd13th3backend.common.dto.ResponseDto;
-import org.minu.dnd13th3backend.screentime.dto.request.ScreenTimePostRequest;
-import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimePostResponse;
+import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimeGenerateResponse;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
 import org.minu.dnd13th3backend.screentime.service.ScreenTimeService;
 import org.minu.dnd13th3backend.user.entity.User;
@@ -22,15 +21,12 @@ public class ScreenTimeController {
     private final ScreenTimeService screenTimeService;
 
     @PostMapping
-    public ResponseEntity<ResponseDto<ScreenTimePostResponse>> registerScreenTime(
-            @RequestBody ScreenTimePostRequest requestDto,
+    public ResponseEntity<ResponseDto<ScreenTimeGenerateResponse>> generateScreenTime(
             @AuthenticationPrincipal User user
     ) {
-        ScreenTime screenTime = screenTimeService.registerOrUpdateScreenTime(requestDto, user);
-
-        ScreenTimePostResponse response = new ScreenTimePostResponse(screenTime);
-
-        return ResponseEntity.ok(ResponseDto.success("스크린타임이 성공적으로 등록/갱신되었습니다.", response));
+        ScreenTime screenTime = screenTimeService.generateAndSaveScreenTime(user);
+        ScreenTimeGenerateResponse response = new ScreenTimeGenerateResponse(screenTime);
+        return ResponseEntity.ok(ResponseDto.success("스크린타임이 성공적으로 생성/갱신되었습니다.", response));
     }
 
     @GetMapping
@@ -40,6 +36,6 @@ public class ScreenTimeController {
             @AuthenticationPrincipal User user
     ) {
         Object responseData = screenTimeService.getScreenTime(period, date, user);
-        return ResponseEntity.ok(ResponseDto.success("스크린타임 조회가 성공했습니다.", responseData));
+        return ResponseEntity.ok(ResponseDto.success("스크린타임 조회에 성공했습니다.", responseData));
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGenerateResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGenerateResponse.java
@@ -6,13 +6,13 @@ import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
 import java.time.LocalDate;
 
 @Getter
-public class ScreenTimePostResponse {
+public class ScreenTimeGenerateResponse {
 
     private final Long id;
     private final LocalDate date;
-    private final Integer screentimeMinutes; // screentime_minutes -> screentimeMinutes
+    private final Integer screentimeMinutes;
 
-    public ScreenTimePostResponse(ScreenTime screenTime) {
+    public ScreenTimeGenerateResponse(ScreenTime screenTime) {
         this.id = screenTime.getId();
         this.date = screenTime.getDate();
         this.screentimeMinutes = screenTime.getScreentimeMinutes();

--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -1,21 +1,25 @@
 package org.minu.dnd13th3backend.screentime.service;
 
 import lombok.RequiredArgsConstructor;
-import org.minu.dnd13th3backend.screentime.dto.request.ScreenTimePostRequest;
-import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimeGetDailyResponse; // DTO import 이름 변경
+import org.minu.dnd13th3backend.user.entity.Profile;
+import org.minu.dnd13th3backend.user.repository.ProfileRepository;
+import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimeGetDailyResponse;
 import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimeGetWeeklyResponse;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
 import org.minu.dnd13th3backend.screentime.repository.ScreenTimeRepository;
 import org.minu.dnd13th3backend.user.entity.User;
+import org.minu.dnd13th3backend.user.type.ScreenTimeGoalType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,23 +27,65 @@ import java.util.stream.Collectors;
 public class ScreenTimeService {
 
     private final ScreenTimeRepository screenTimeRepository;
+    private final ProfileRepository profileRepository;
+    private final Random random = new Random();
 
     @Transactional
-    public ScreenTime registerOrUpdateScreenTime(ScreenTimePostRequest requestDto, User user) {
-        Optional<ScreenTime> optionalScreenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), requestDto.getDate());
+    public ScreenTime generateAndSaveScreenTime(User user) {
+        LocalDate today = LocalDate.now();
+        Optional<ScreenTime> optionalScreenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), today);
 
-        if (optionalScreenTime.isPresent()) {
-            ScreenTime screenTime = optionalScreenTime.get();
-            screenTime.updateScreenTime(requestDto.getScreentimeMinutes());
-            return screenTime;
+        int currentMinutes = optionalScreenTime.map(ScreenTime::getScreentimeMinutes).orElse(0);
+
+        Profile profile = profileRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new IllegalStateException("해당 사용자의 프로필을 찾을 수 없습니다: " + user.getId()));
+
+        int goalMinutes = getGoalMinutes(profile);
+
+        int maxMinutesForNow = calculateCurrentMaxMinutes(goalMinutes);
+
+        int newMinimum = currentMinutes + 1;
+
+        int randomMinutes;
+
+        if (newMinimum < maxMinutesForNow) {
+            randomMinutes = random.nextInt(maxMinutesForNow - newMinimum + 1) + newMinimum;
         } else {
-            ScreenTime newScreenTime = ScreenTime.builder()
-                    .user(user)
-                    .date(requestDto.getDate())
-                    .screentimeMinutes(requestDto.getScreentimeMinutes())
-                    .build();
-            return screenTimeRepository.save(newScreenTime);
+            randomMinutes = currentMinutes;
         }
+
+        ScreenTime screenTime;
+        if (optionalScreenTime.isPresent()) {
+            screenTime = optionalScreenTime.get();
+            if (randomMinutes > currentMinutes) {
+                screenTime.updateScreenTime(randomMinutes);
+            }
+        } else {
+            screenTime = ScreenTime.builder()
+                    .user(user)
+                    .date(today)
+                    .screentimeMinutes(randomMinutes)
+                    .build();
+        }
+
+        return screenTimeRepository.save(screenTime);
+    }
+
+    private int getGoalMinutes(Profile profile) {
+        if (profile.getScreenTimeGoalType() == ScreenTimeGoalType.CUSTOM) {
+            try {
+                return Integer.parseInt(profile.getScreenTimeGoalCustom());
+            } catch (NumberFormatException e) {
+                return 240;
+            }
+        }
+        return profile.getScreenTimeGoalType().getMinutes();
+    }
+
+    private int calculateCurrentMaxMinutes(int goalMinutes) {
+        double dayProgressRatio = (double) LocalTime.now().toSecondOfDay() / (24.0 * 3600.0);
+        int maxMinutes = (int) (goalMinutes * dayProgressRatio);
+        return Math.min(maxMinutes, goalMinutes);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/minu/dnd13th3backend/user/entity/User.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/entity/User.java
@@ -41,4 +41,7 @@ public class User {
         this.name = name;
         this.email = email;
     }
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Profile profile;
 }


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- user entity 코드에 user_id를 통해 사용자의 profile을 조회하는 메서드를 추가했습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Screen Time: POST now auto-generates today’s screen time based on user profile and time of day, returning a new response format.

- Refactor
  - Screen Time: POST endpoint renamed and no longer requires a request body; minor success message update on GET.

- Chores
  - Added initial scaffolding for the Challenge module (controllers, DTOs, entities, repositories, service, types) in preparation for future features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->