### PR TITLE
feat: 개인/공유 챌린지 생성 및 조회 api 구현

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
@@ -1,4 +1,48 @@
 package org.minu.dnd13th3backend.challenge.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.minu.dnd13th3backend.challenge.dto.request.ChallengeCreateRequest;
+import org.minu.dnd13th3backend.challenge.dto.response.ChallengeCreateResponse;
+import org.minu.dnd13th3backend.challenge.dto.response.ChallengeGetResponse;
+import org.minu.dnd13th3backend.challenge.entity.Challenge;
+import org.minu.dnd13th3backend.challenge.service.ChallengeService;
+import org.minu.dnd13th3backend.challenge.type.ChallengeType;
+import org.minu.dnd13th3backend.common.dto.ResponseDto;
+import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/challenge")
+@RequiredArgsConstructor
 public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDto<ChallengeCreateResponse>> createChallenge(
+            @RequestBody ChallengeCreateRequest request,
+            @AuthenticationPrincipal User user
+    ) {
+        Challenge challenge = challengeService.createChallenge(request, user);
+
+        ChallengeCreateResponse responseData = new ChallengeCreateResponse(challenge.getId());
+
+        return ResponseEntity.ok(ResponseDto.success("챌린지가 성공적으로 생성되었습니다.", responseData));
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<ChallengeGetResponse>> getChallenge(
+            @RequestParam("type") ChallengeType type,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @AuthenticationPrincipal User user
+    ) {
+        ChallengeGetResponse responseData = challengeService.getChallenge(type, startDate, endDate, user);
+        return ResponseEntity.ok(ResponseDto.success("챌린지 조회가 성공했습니다.", responseData));
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/ChallengeCreateRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/ChallengeCreateRequest.java
@@ -1,4 +1,4 @@
-package org.minu.dnd13th3backend.challenge.dto;
+package org.minu.dnd13th3backend.challenge.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeCreateResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeCreateResponse.java
@@ -1,4 +1,4 @@
-package org.minu.dnd13th3backend.challenge.dto;
+package org.minu.dnd13th3backend.challenge.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeGetResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeGetResponse.java
@@ -1,4 +1,45 @@
 package org.minu.dnd13th3backend.challenge.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import org.minu.dnd13th3backend.challenge.type.ChallengeType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
 public class ChallengeGetResponse {
+
+    private Long challengeId;
+    private ChallengeType type;
+
+    @JsonProperty("start_date")
+    private LocalDate startDate;
+
+    @JsonProperty("end_date")
+    private LocalDate endDate;
+
+    private String title;
+
+    @JsonProperty("goal_time_minutes")
+    private int goalTimeMinutes;
+
+    private List<ParticipantRecord> participants;
+
+    @Getter
+    @Builder
+    public static class ParticipantRecord {
+        private Long userId;
+        private String nickname;
+
+        @JsonProperty("current_time_minutes")
+        private long currentTimeMinutes;
+
+        @JsonProperty("achievement_rate")
+        private double achievementRate;
+
+        private String status;
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/entity/Challenge.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/entity/Challenge.java
@@ -1,4 +1,61 @@
 package org.minu.dnd13th3backend.challenge.entity;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.minu.dnd13th3backend.challenge.type.ChallengeStatus;
+import org.minu.dnd13th3backend.challenge.type.ChallengeType;
+import org.minu.dnd13th3backend.user.entity.User;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Challenge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id")
+    private User creator;
+
+    @Column(length = 100)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private ChallengeType type;
+
+    private int goalTimeMinutes;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    private ChallengeStatus status;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Challenge(User creator, String title, ChallengeType type, int goalTimeMinutes, LocalDate startDate, LocalDate endDate, ChallengeStatus status) {
+        this.creator = creator;
+        this.title = title;
+        this.type = type;
+        this.goalTimeMinutes = goalTimeMinutes;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/entity/ChallengeParticipant.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/entity/ChallengeParticipant.java
@@ -1,4 +1,32 @@
 package org.minu.dnd13th3backend.challenge.entity;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.minu.dnd13th3backend.user.entity.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChallengeParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public ChallengeParticipant(Challenge challenge, User user) {
+        this.challenge = challenge;
+        this.user = user;
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/entity/InviteCode.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/entity/InviteCode.java
@@ -1,4 +1,26 @@
 package org.minu.dnd13th3backend.challenge.entity;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InviteCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+
+    private String code;
+
+    private LocalDate expiresAt;
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
@@ -1,4 +1,24 @@
 package org.minu.dnd13th3backend.challenge.repository;
 
-public class ChallengeParticipantRepository {
+import org.minu.dnd13th3backend.challenge.entity.ChallengeParticipant;
+import org.minu.dnd13th3backend.challenge.type.ChallengeType;
+import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface ChallengeParticipantRepository extends JpaRepository<ChallengeParticipant, Long> {
+
+    List<ChallengeParticipant> findByUserAndChallenge_TypeAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqual(
+            User user, ChallengeType type, LocalDate today1, LocalDate today2
+    );
+
+    List<ChallengeParticipant> findByUserAndChallenge_TypeAndChallenge_StartDateAndChallenge_EndDate(
+            User user, ChallengeType type, LocalDate startDate, LocalDate endDate
+    );
+
+    List<ChallengeParticipant> findByChallenge_Id(Long challengeId);
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeRepository.java
@@ -1,4 +1,9 @@
 package org.minu.dnd13th3backend.challenge.repository;
 
-public class ChallengeRepository {
+import org.minu.dnd13th3backend.challenge.entity.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
@@ -1,4 +1,124 @@
 package org.minu.dnd13th3backend.challenge.service;
 
+import lombok.RequiredArgsConstructor;
+import org.minu.dnd13th3backend.challenge.dto.request.ChallengeCreateRequest;
+import org.minu.dnd13th3backend.challenge.dto.response.ChallengeGetResponse;
+import org.minu.dnd13th3backend.challenge.entity.Challenge;
+import org.minu.dnd13th3backend.challenge.entity.ChallengeParticipant;
+import org.minu.dnd13th3backend.challenge.repository.ChallengeParticipantRepository;
+import org.minu.dnd13th3backend.challenge.repository.ChallengeRepository;
+import org.minu.dnd13th3backend.challenge.type.ChallengeStatus;
+import org.minu.dnd13th3backend.challenge.type.ChallengeType;
+import org.minu.dnd13th3backend.common.exception.BusinessException;
+import org.minu.dnd13th3backend.common.exception.ErrorCode;
+import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
+import org.minu.dnd13th3backend.screentime.repository.ScreenTimeRepository;
+import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
 public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeParticipantRepository participantRepository;
+    private final ScreenTimeRepository screenTimeRepository;
+
+    @Transactional
+    public Challenge createChallenge(ChallengeCreateRequest request, User user) {
+        Challenge challenge = Challenge.builder()
+                .creator(user)
+                .title(request.getTitle())
+                .type(request.getType())
+                .goalTimeMinutes(request.getGoalTimeMinutes())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .status(ChallengeStatus.IN_PROGRESS)
+                .build();
+
+        Challenge savedChallenge = challengeRepository.save(challenge);
+
+        ChallengeParticipant participant = ChallengeParticipant.builder()
+                .challenge(savedChallenge)
+                .user(user)
+                .build();
+
+        participantRepository.save(participant);
+
+        return savedChallenge;
+    }
+
+    @Transactional(readOnly = true)
+    public ChallengeGetResponse getChallenge(ChallengeType type, LocalDate startDate, LocalDate endDate, User user) {
+
+        List<ChallengeParticipant> userParticipation;
+        boolean isCompletedChallenge = (startDate != null && endDate != null);
+
+        if (isCompletedChallenge) {
+            userParticipation = participantRepository.findByUserAndChallenge_TypeAndChallenge_StartDateAndChallenge_EndDate(user, type, startDate, endDate);
+        } else {
+            LocalDate today = LocalDate.now();
+            userParticipation = participantRepository.findByUserAndChallenge_TypeAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqual(user, type, today, today);
+        }
+
+        if (userParticipation.isEmpty()) {
+            throw new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND);
+        }
+        Challenge challenge = userParticipation.get(0).getChallenge();
+
+        List<ChallengeParticipant> allParticipants = participantRepository.findByChallenge_Id(challenge.getId());
+
+        List<ChallengeGetResponse.ParticipantRecord> participantRecords = allParticipants.stream()
+                .map(participant -> {
+                    User participantUser = participant.getUser();
+
+                    List<ScreenTime> screenTimes = screenTimeRepository.findByUser_IdAndDateBetween(
+                            participantUser.getId(), challenge.getStartDate(), challenge.getEndDate()
+                    );
+
+                    long currentTimeMinutes = screenTimes.stream()
+                            .mapToLong(ScreenTime::getScreentimeMinutes)
+                            .sum();
+
+                    double achievementRate;
+                    if (challenge.getGoalTimeMinutes() > 0) {
+                        double usageRate = ((double) currentTimeMinutes / challenge.getGoalTimeMinutes()) * 100.0;
+
+                        achievementRate = Math.max(0, 100.0 - usageRate);
+                    } else {
+                        achievementRate = (currentTimeMinutes == 0) ? 100.0 : 0.0;
+                    }
+
+                    String status;
+                    if (isCompletedChallenge) {
+                        status = (currentTimeMinutes <= challenge.getGoalTimeMinutes()) ? "달성" : "실패";
+                    } else {
+                        status = "진행 중";
+                    }
+
+                    return ChallengeGetResponse.ParticipantRecord.builder()
+                            .userId(participantUser.getId())
+                            .nickname(participantUser.getProfile().getNickname())
+                            .currentTimeMinutes(currentTimeMinutes)
+                            .achievementRate(achievementRate)
+                            .status(status)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return ChallengeGetResponse.builder()
+                .challengeId(challenge.getId())
+                .type(challenge.getType())
+                .startDate(challenge.getStartDate())
+                .endDate(challenge.getEndDate())
+                .title(challenge.getTitle())
+                .goalTimeMinutes(challenge.getGoalTimeMinutes())
+                .participants(participantRecords)
+                .build();
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeStatus.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeStatus.java
@@ -1,4 +1,7 @@
 package org.minu.dnd13th3backend.challenge.type;
 
-public class ChallengeStatus {
+public enum ChallengeStatus {
+    IN_PROGRESS,
+    ACHIEVED,
+    FAILED
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeType.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeType.java
@@ -1,4 +1,6 @@
 package org.minu.dnd13th3backend.challenge.type;
 
-public class ChallengeType {
+public enum ChallengeType {
+    PERSONAL,
+    SHARE
 }

--- a/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필을 찾을 수 없습니다."),
     PROFILE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 프로필이 존재합니다."),
+    CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 챌린지를 찾을 수 없습니다."),
     
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),


### PR DESCRIPTION
## 관련 이슈
#45 

## 작업 내용
- 개인/공유 챌린지 생성 api 구현
- 개인/공유 및 진행 중/완료 챌린지 조회 api 구현
- 각 api의 parameter 및 type 선언 방법은 api 명세서를 참고해주시면 감사하겠습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Create a new challenge via API.
  - Retrieve a challenge by type with optional date range.
  - View challenge details: title, period, goal time, and participant progress (current time, achievement rate, status).
  - Supports personal and shared challenge types.
  - Authenticated responses with localized success messages.

- Improvements
  - Standardized challenge statuses (In Progress, Achieved, Failed).
  - Clear error returned when a challenge is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->