### PR TITLE
fix: deploy.yml mysql 연결 설정 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,8 @@ jobs:
               db:
                 image: mysql:8.0
                 container_name: mysql-db
+                ports:
+                  - "3306:3306"
                 env_file:
                   - ./.env
                 volumes:


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- deploy.yml mysql 연결 설정 수정(3306:3306)

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - MySQL is now accessible from the host in EC2 deployments via port 3306, enabling direct external connections while preserving internal networking for services.
- Chores
  - Updated deployment workflow to publish MySQL container port 3306 to the host, without modifying other service configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->