### PR TITLE
fix: 스크린타임 생성, 조회 + 챌린지 조회  api 수정 - 4개의 어플(카카오, 크롬, 인스타, 유튜브) 값 반영

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
@@ -82,20 +82,19 @@ public class ChallengeService {
                     );
 
                     long currentTimeMinutes = screenTimes.stream()
-                            .mapToLong(ScreenTime::getScreentimeMinutes)
+                            .mapToLong(st -> st.getInstagramMinutes() + st.getYoutubeMinutes() + st.getKakaotalkMinutes() + st.getChromeMinutes())
                             .sum();
 
                     double achievementRate;
                     if (challenge.getGoalTimeMinutes() > 0) {
                         double usageRate = ((double) currentTimeMinutes / challenge.getGoalTimeMinutes()) * 100.0;
-
                         achievementRate = Math.max(0, 100.0 - usageRate);
                     } else {
                         achievementRate = (currentTimeMinutes == 0) ? 100.0 : 0.0;
                     }
 
                     String status;
-                    if (isCompletedChallenge) {
+                    if (LocalDate.now().isAfter(challenge.getEndDate())) {
                         status = (currentTimeMinutes <= challenge.getGoalTimeMinutes()) ? "달성" : "실패";
                     } else {
                         status = "진행 중";

--- a/src/main/java/org/minu/dnd13th3backend/screentime/controller/ScreenTimeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/controller/ScreenTimeController.java
@@ -25,7 +25,7 @@ public class ScreenTimeController {
             @AuthenticationPrincipal User user
     ) {
         ScreenTime screenTime = screenTimeService.generateAndSaveScreenTime(user);
-        ScreenTimeGenerateResponse response = new ScreenTimeGenerateResponse(screenTime);
+        ScreenTimeGenerateResponse response = ScreenTimeGenerateResponse.from(screenTime);
         return ResponseEntity.ok(ResponseDto.success("스크린타임이 성공적으로 생성/갱신되었습니다.", response));
     }
 

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGenerateResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGenerateResponse.java
@@ -1,20 +1,41 @@
 package org.minu.dnd13th3backend.screentime.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
-
 import java.time.LocalDate;
 
 @Getter
+@Builder
 public class ScreenTimeGenerateResponse {
+    private Long id;
+    private LocalDate date;
+    private int totalMinutes;
+    private AppTimeDetails appTimes;
 
-    private final Long id;
-    private final LocalDate date;
-    private final Integer screentimeMinutes;
+    public static ScreenTimeGenerateResponse from(ScreenTime screenTime) {
+        int total = screenTime.getInstagramMinutes() + screenTime.getYoutubeMinutes() +
+                screenTime.getKakaotalkMinutes() + screenTime.getChromeMinutes();
+        return ScreenTimeGenerateResponse.builder()
+                .id(screenTime.getId())
+                .date(screenTime.getDate())
+                .totalMinutes(total)
+                .appTimes(new AppTimeDetails(screenTime))
+                .build();
+    }
 
-    public ScreenTimeGenerateResponse(ScreenTime screenTime) {
-        this.id = screenTime.getId();
-        this.date = screenTime.getDate();
-        this.screentimeMinutes = screenTime.getScreentimeMinutes();
+    @Getter
+    public static class AppTimeDetails {
+        private int instagram;
+        private int youtube;
+        private int kakaotalk;
+        private int chrome;
+
+        public AppTimeDetails(ScreenTime screenTime) {
+            this.instagram = screenTime.getInstagramMinutes();
+            this.youtube = screenTime.getYoutubeMinutes();
+            this.kakaotalk = screenTime.getKakaotalkMinutes();
+            this.chrome = screenTime.getChromeMinutes();
+        }
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetDailyResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetDailyResponse.java
@@ -1,41 +1,51 @@
 package org.minu.dnd13th3backend.screentime.dto.response;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
-
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 @Builder
 public class ScreenTimeGetDailyResponse {
-
-    private List<ScreenTimeData> screenTimes;
+    private List<DailyScreenTime> screenTimes;
 
     public static ScreenTimeGetDailyResponse from(ScreenTime screenTime) {
         if (screenTime == null) {
-            return ScreenTimeGetDailyResponse.builder()
-                    .screenTimes(List.of())
-                    .build();
+            return ScreenTimeGetDailyResponse.builder().screenTimes(List.of()).build();
         }
-        List<ScreenTimeData> data = List.of(new ScreenTimeData(screenTime));
         return ScreenTimeGetDailyResponse.builder()
-                .screenTimes(data)
+                .screenTimes(List.of(new DailyScreenTime(screenTime)))
                 .build();
     }
 
     @Getter
-    @AllArgsConstructor
-    public static class ScreenTimeData {
+    public static class DailyScreenTime {
         private LocalDate date;
-        private int screentimeMinutes;
+        private int totalMinutes;
+        private AppTimeDetails appTimes;
 
-        public ScreenTimeData(ScreenTime screenTime) {
+        public DailyScreenTime(ScreenTime screenTime) {
             this.date = screenTime.getDate();
-            this.screentimeMinutes = screenTime.getScreentimeMinutes();
+            this.totalMinutes = screenTime.getInstagramMinutes() + screenTime.getYoutubeMinutes() +
+                    screenTime.getKakaotalkMinutes() + screenTime.getChromeMinutes();
+            this.appTimes = new AppTimeDetails(screenTime);
+        }
+    }
+
+    @Getter
+    public static class AppTimeDetails {
+        private int instagram;
+        private int youtube;
+        private int kakaotalk;
+        private int chrome;
+
+        public AppTimeDetails(ScreenTime screenTime) {
+            this.instagram = screenTime.getInstagramMinutes();
+            this.youtube = screenTime.getYoutubeMinutes();
+            this.kakaotalk = screenTime.getKakaotalkMinutes();
+            this.chrome = screenTime.getChromeMinutes();
         }
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetWeeklyResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetWeeklyResponse.java
@@ -1,39 +1,35 @@
 package org.minu.dnd13th3backend.screentime.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
 @Builder
 public class ScreenTimeGetWeeklyResponse {
-
     private String period;
-
-    @JsonProperty("start_date")
     private LocalDate startDate;
-
-    @JsonProperty("end_date")
     private LocalDate endDate;
-
-    @JsonProperty("total_minutes")
     private int totalMinutes;
-
-    @JsonProperty("average_minutes")
     private double averageMinutes;
-
-    @JsonProperty("daily_records")
+    private AppTimeDetails weeklyAppTotals;
     private List<DailyRecord> dailyRecords;
+
+    @Getter
+    @Builder
+    public static class AppTimeDetails {
+        private int instagram;
+        private int youtube;
+        private int kakaotalk;
+        private int chrome;
+    }
 
     @Getter
     @Builder
     public static class DailyRecord {
         private LocalDate date;
-
-        @JsonProperty("screentime_minutes")
-        private int screentimeMinutes;
+        private int totalMinutes;
+        private AppTimeDetails appTimes;
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/entity/ScreenTime.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/entity/ScreenTime.java
@@ -23,16 +23,26 @@ public class ScreenTime {
     private User user;
 
     private LocalDate date;
-    private Integer screentimeMinutes;
+
+    private int instagramMinutes;
+    private int youtubeMinutes;
+    private int kakaotalkMinutes;
+    private int chromeMinutes;
 
     @Builder
-    public ScreenTime(User user, LocalDate date, Integer screentimeMinutes) {
+    public ScreenTime(User user, LocalDate date, int instagramMinutes, int youtubeMinutes, int kakaotalkMinutes, int chromeMinutes) {
         this.user = user;
         this.date = date;
-        this.screentimeMinutes = screentimeMinutes;
+        this.instagramMinutes = instagramMinutes;
+        this.youtubeMinutes = youtubeMinutes;
+        this.kakaotalkMinutes = kakaotalkMinutes;
+        this.chromeMinutes = chromeMinutes;
     }
 
-    public void updateScreenTime(Integer minutes) {
-        this.screentimeMinutes = minutes;
+    public void updateScreenTime(int instagramMinutes, int youtubeMinutes, int kakaotalkMinutes, int chromeMinutes) {
+        this.instagramMinutes = instagramMinutes;
+        this.youtubeMinutes = youtubeMinutes;
+        this.kakaotalkMinutes = kakaotalkMinutes;
+        this.chromeMinutes = chromeMinutes;
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -1,13 +1,13 @@
 package org.minu.dnd13th3backend.screentime.service;
 
 import lombok.RequiredArgsConstructor;
-import org.minu.dnd13th3backend.user.entity.Profile;
-import org.minu.dnd13th3backend.user.repository.ProfileRepository;
 import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimeGetDailyResponse;
 import org.minu.dnd13th3backend.screentime.dto.response.ScreenTimeGetWeeklyResponse;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
 import org.minu.dnd13th3backend.screentime.repository.ScreenTimeRepository;
+import org.minu.dnd13th3backend.user.entity.Profile;
 import org.minu.dnd13th3backend.user.entity.User;
+import org.minu.dnd13th3backend.user.repository.ProfileRepository;
 import org.minu.dnd13th3backend.user.type.ScreenTimeGoalType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,11 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Random;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -35,40 +31,71 @@ public class ScreenTimeService {
         LocalDate today = LocalDate.now();
         Optional<ScreenTime> optionalScreenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), today);
 
-        int currentMinutes = optionalScreenTime.map(ScreenTime::getScreentimeMinutes).orElse(0);
+        int prevInsta = optionalScreenTime.map(ScreenTime::getInstagramMinutes).orElse(0);
+        int prevYoutube = optionalScreenTime.map(ScreenTime::getYoutubeMinutes).orElse(0);
+        int prevKakaotalk = optionalScreenTime.map(ScreenTime::getKakaotalkMinutes).orElse(0);
+        int prevChrome = optionalScreenTime.map(ScreenTime::getChromeMinutes).orElse(0);
+        int currentTotalMinutes = prevInsta + prevYoutube + prevKakaotalk + prevChrome;
 
         Profile profile = profileRepository.findByUserId(user.getId())
                 .orElseThrow(() -> new IllegalStateException("해당 사용자의 프로필을 찾을 수 없습니다: " + user.getId()));
-
         int goalMinutes = getGoalMinutes(profile);
-
         int maxMinutesForNow = calculateCurrentMaxMinutes(goalMinutes);
 
-        int newMinimum = currentMinutes + 1;
-
-        int randomMinutes;
-
-        if (newMinimum < maxMinutesForNow) {
-            randomMinutes = random.nextInt(maxMinutesForNow - newMinimum + 1) + newMinimum;
-        } else {
-            randomMinutes = currentMinutes;
-        }
+        int remainingBudget = maxMinutesForNow - currentTotalMinutes;
 
         ScreenTime screenTime;
         if (optionalScreenTime.isPresent()) {
             screenTime = optionalScreenTime.get();
-            if (randomMinutes > currentMinutes) {
-                screenTime.updateScreenTime(randomMinutes);
+            if (remainingBudget > 0) {
+                int totalIncrease = random.nextInt(Math.min(remainingBudget, 30)) + 1;
+
+                int[] increases = distributeTotalTime(totalIncrease, 4);
+
+                screenTime.updateScreenTime(
+                        prevInsta + increases[0],
+                        prevYoutube + increases[1],
+                        prevKakaotalk + increases[2],
+                        prevChrome + increases[3]
+                );
             }
         } else {
+            int initialTotalMinutes = 0;
+            if (maxMinutesForNow > 0) {
+                initialTotalMinutes = random.nextInt(Math.min(maxMinutesForNow, 30)) + 1;
+            }
+
+            int[] appMinutes = distributeTotalTime(initialTotalMinutes, 4);
             screenTime = ScreenTime.builder()
                     .user(user)
                     .date(today)
-                    .screentimeMinutes(randomMinutes)
+                    .instagramMinutes(appMinutes[0])
+                    .youtubeMinutes(appMinutes[1])
+                    .kakaotalkMinutes(appMinutes[2])
+                    .chromeMinutes(appMinutes[3])
                     .build();
         }
-
         return screenTimeRepository.save(screenTime);
+    }
+
+    private int[] distributeTotalTime(int total, int parts) {
+        int[] result = new int[parts];
+        if (total <= 0) return result;
+        int currentTotal = 0;
+        for (int i = 0; i < parts - 1; i++) {
+            if (currentTotal >= total) break;
+            int value = random.nextInt(total - currentTotal + 1);
+            result[i] = value;
+            currentTotal += value;
+        }
+        result[parts - 1] = total - currentTotal;
+
+        List<Integer> list = Arrays.stream(result).boxed().collect(Collectors.toList());
+        Collections.shuffle(list);
+        for(int i=0; i<parts; i++) {
+            result[i] = list.get(i);
+        }
+        return result;
     }
 
     private int getGoalMinutes(Profile profile) {
@@ -101,9 +128,7 @@ public class ScreenTimeService {
 
     private ScreenTimeGetDailyResponse getDailyScreenTime(LocalDate date, User user) {
         LocalDate targetDate = (date == null) ? LocalDate.now() : date;
-        ScreenTime screenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), targetDate)
-                .orElse(null);
-
+        ScreenTime screenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), targetDate).orElse(null);
         return ScreenTimeGetDailyResponse.from(screenTime);
     }
 
@@ -113,21 +138,40 @@ public class ScreenTimeService {
         LocalDate endOfWeek = today.with(DayOfWeek.SUNDAY);
 
         List<ScreenTime> recordedTimes = screenTimeRepository.findByUser_IdAndDateBetween(user.getId(), startOfWeek, endOfWeek);
-
-        Map<LocalDate, Integer> recordedMap = recordedTimes.stream()
-                .collect(Collectors.toMap(ScreenTime::getDate, ScreenTime::getScreentimeMinutes));
+        Map<LocalDate, ScreenTime> recordedMap = recordedTimes.stream().collect(Collectors.toMap(ScreenTime::getDate, st -> st));
 
         List<ScreenTimeGetWeeklyResponse.DailyRecord> dailyRecords = new ArrayList<>();
+        int totalInsta = 0, totalYoutube = 0, totalKakaotalk = 0, totalChrome = 0;
+
         for (LocalDate d = startOfWeek; !d.isAfter(endOfWeek); d = d.plusDays(1)) {
-            int minutes = recordedMap.getOrDefault(d, 0);
-            dailyRecords.add(ScreenTimeGetWeeklyResponse.DailyRecord.builder()
-                    .date(d)
-                    .screentimeMinutes(minutes)
-                    .build());
+            ScreenTime st = recordedMap.get(d);
+            if (st != null) {
+                totalInsta += st.getInstagramMinutes();
+                totalYoutube += st.getYoutubeMinutes();
+                totalKakaotalk += st.getKakaotalkMinutes();
+                totalChrome += st.getChromeMinutes();
+
+                dailyRecords.add(ScreenTimeGetWeeklyResponse.DailyRecord.builder()
+                        .date(d)
+                        .totalMinutes(st.getInstagramMinutes() + st.getYoutubeMinutes() + st.getKakaotalkMinutes() + st.getChromeMinutes())
+                        .appTimes(ScreenTimeGetWeeklyResponse.AppTimeDetails.builder()
+                                .instagram(st.getInstagramMinutes())
+                                .youtube(st.getYoutubeMinutes())
+                                .kakaotalk(st.getKakaotalkMinutes())
+                                .chrome(st.getChromeMinutes())
+                                .build())
+                        .build());
+            } else {
+                dailyRecords.add(ScreenTimeGetWeeklyResponse.DailyRecord.builder()
+                        .date(d)
+                        .totalMinutes(0)
+                        .appTimes(ScreenTimeGetWeeklyResponse.AppTimeDetails.builder().instagram(0).youtube(0).kakaotalk(0).chrome(0).build())
+                        .build());
+            }
         }
 
-        int totalMinutes = dailyRecords.stream().mapToInt(ScreenTimeGetWeeklyResponse.DailyRecord::getScreentimeMinutes).sum();
-        double averageMinutes = (double) totalMinutes / 7.0;
+        int totalMinutes = totalInsta + totalYoutube + totalKakaotalk + totalChrome;
+        double averageMinutes = (recordedTimes.isEmpty()) ? 0.0 : (double) totalMinutes / 7.0;
 
         return ScreenTimeGetWeeklyResponse.builder()
                 .period("week")
@@ -135,6 +179,12 @@ public class ScreenTimeService {
                 .endDate(endOfWeek)
                 .totalMinutes(totalMinutes)
                 .averageMinutes(averageMinutes)
+                .weeklyAppTotals(ScreenTimeGetWeeklyResponse.AppTimeDetails.builder()
+                        .instagram(totalInsta)
+                        .youtube(totalYoutube)
+                        .kakaotalk(totalKakaotalk)
+                        .chrome(totalChrome)
+                        .build())
                 .dailyRecords(dailyRecords)
                 .build();
     }


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 스크린 타임 값에 4개의 어플(인스타, 카카오톡, 크롬, 유튜브) 값을 넣도록 반영했습니다.
- 반영 시 수정이 필요한 스크린타임 생성/조회, 챌린지 조회 api를 수정하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Daily and weekly screen time now show total minutes plus per-app breakdowns (Instagram, YouTube, KakaoTalk, Chrome).
  - Weekly reports include per-app totals alongside daily records.
  - Screen time totals are calculated from per-app usage for greater accuracy.
  - Challenge status updates automatically after the challenge end date: marked as achieved or failed based on total time vs goal, otherwise shown as in progress.
  - Challenge retrieval supports specifying an end date for more precise period summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->