### PR TITLE
feat: 챌린지 링크 생성 및 수락 api 구현

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
@@ -2,8 +2,11 @@ package org.minu.dnd13th3backend.challenge.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.minu.dnd13th3backend.challenge.dto.request.ChallengeCreateRequest;
+import org.minu.dnd13th3backend.challenge.dto.request.InviteJoinRequest;
 import org.minu.dnd13th3backend.challenge.dto.response.ChallengeCreateResponse;
 import org.minu.dnd13th3backend.challenge.dto.response.ChallengeGetResponse;
+import org.minu.dnd13th3backend.challenge.dto.response.InviteJoinResponse;
+import org.minu.dnd13th3backend.challenge.dto.response.InviteUrlCreateResponse;
 import org.minu.dnd13th3backend.challenge.entity.Challenge;
 import org.minu.dnd13th3backend.challenge.service.ChallengeService;
 import org.minu.dnd13th3backend.challenge.type.ChallengeType;
@@ -44,5 +47,24 @@ public class ChallengeController {
     ) {
         ChallengeGetResponse responseData = challengeService.getChallenge(type, startDate, endDate, user);
         return ResponseEntity.ok(ResponseDto.success("챌린지 조회가 성공했습니다.", responseData));
+    }
+
+    @PostMapping("/inviteUrl")
+    public ResponseEntity<ResponseDto<InviteUrlCreateResponse>> createInviteUrl(
+            @AuthenticationPrincipal User user
+    ) {
+        String url = challengeService.generateInviteLink(user);
+        InviteUrlCreateResponse response = new InviteUrlCreateResponse(url);
+        return ResponseEntity.ok(ResponseDto.success("초대 링크가 성공적으로 생성되었습니다.", response));
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<ResponseDto<InviteJoinResponse>> joinChallenge(
+            @RequestBody InviteJoinRequest request,
+            @AuthenticationPrincipal User user
+    ) {
+        Challenge challenge = challengeService.joinChallenge(request, user);
+        InviteJoinResponse response = new InviteJoinResponse(challenge, "챌린지에 성공적으로 참여했습니다.");
+        return ResponseEntity.ok(ResponseDto.success(response.getMessage(), response));
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/InviteJoinRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/InviteJoinRequest.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.dto.request;
+
+public class InviteJoinRequest {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/InviteJoinRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/InviteJoinRequest.java
@@ -1,4 +1,13 @@
 package org.minu.dnd13th3backend.challenge.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class InviteJoinRequest {
+
+    @JsonProperty("invite_code")
+    private String inviteCode;
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteJoinResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteJoinResponse.java
@@ -1,4 +1,32 @@
 package org.minu.dnd13th3backend.challenge.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import org.minu.dnd13th3backend.challenge.entity.Challenge;
+
+import java.time.LocalDate;
+
+@Getter
 public class InviteJoinResponse {
+
+    private final String message;
+
+    @JsonProperty("challenge_id")
+    private final Long challengeId;
+
+    @JsonProperty("start_date")
+    private final LocalDate startDate;
+
+    @JsonProperty("end_date")
+    private final LocalDate endDate;
+
+    private final String title;
+
+    public InviteJoinResponse(Challenge challenge, String message) {
+        this.message = message;
+        this.challengeId = challenge.getId();
+        this.startDate = challenge.getStartDate();
+        this.endDate = challenge.getEndDate();
+        this.title = challenge.getTitle();
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteJoinResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteJoinResponse.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.dto.response;
+
+public class InviteJoinResponse {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteUrlCreateResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteUrlCreateResponse.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.dto.response;
+
+public class InviteUrlCreateResponse {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteUrlCreateResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteUrlCreateResponse.java
@@ -1,4 +1,13 @@
 package org.minu.dnd13th3backend.challenge.dto.response;
 
+import lombok.Getter;
+
+@Getter
 public class InviteUrlCreateResponse {
+
+    private final String url;
+
+    public InviteUrlCreateResponse(String url) {
+        this.url = url;
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/entity/InviteCode.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/entity/InviteCode.java
@@ -2,6 +2,7 @@ package org.minu.dnd13th3backend.challenge.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder; // import 추가
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,11 @@ public class InviteCode {
     private String code;
 
     private LocalDate expiresAt;
+
+    @Builder
+    public InviteCode(Challenge challenge, String code, LocalDate expiresAt) {
+        this.challenge = challenge;
+        this.code = code;
+        this.expiresAt = expiresAt;
+    }
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
@@ -1,5 +1,6 @@
 package org.minu.dnd13th3backend.challenge.repository;
 
+import org.minu.dnd13th3backend.challenge.entity.Challenge;
 import org.minu.dnd13th3backend.challenge.entity.ChallengeParticipant;
 import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 import org.minu.dnd13th3backend.user.entity.User;
@@ -8,17 +9,22 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChallengeParticipantRepository extends JpaRepository<ChallengeParticipant, Long> {
 
-    List<ChallengeParticipant> findByUserAndChallenge_TypeAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqual(
+    Optional<ChallengeParticipant> findFirstByUserAndChallenge_TypeAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqualOrderByChallenge_CreatedAtDesc(
             User user, ChallengeType type, LocalDate today1, LocalDate today2
     );
 
-    List<ChallengeParticipant> findByUserAndChallenge_TypeAndChallenge_StartDateAndChallenge_EndDate(
+    Optional<ChallengeParticipant> findFirstByUserAndChallenge_TypeAndChallenge_StartDateAndChallenge_EndDateOrderByChallenge_CreatedAtDesc(
             User user, ChallengeType type, LocalDate startDate, LocalDate endDate
     );
 
     List<ChallengeParticipant> findByChallenge_Id(Long challengeId);
+
+    boolean existsByChallengeAndUser(Challenge challenge, User user);
+
+    long countByChallenge(Challenge challenge);
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeRepository.java
@@ -1,9 +1,16 @@
 package org.minu.dnd13th3backend.challenge.repository;
 
 import org.minu.dnd13th3backend.challenge.entity.Challenge;
+import org.minu.dnd13th3backend.challenge.type.ChallengeType;
+import org.minu.dnd13th3backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+    Optional<Challenge> findTopByCreatorAndTypeOrderByCreatedAtDesc(User creator, ChallengeType type);
 }
+

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/InviteCodeRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/InviteCodeRepository.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.repository;
+
+public class InviteCodeRepository {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/InviteCodeRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/InviteCodeRepository.java
@@ -1,4 +1,14 @@
 package org.minu.dnd13th3backend.challenge.repository;
 
-public class InviteCodeRepository {
+import org.minu.dnd13th3backend.challenge.entity.Challenge;
+import org.minu.dnd13th3backend.challenge.entity.InviteCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface InviteCodeRepository extends JpaRepository<InviteCode, Long> {
+    Optional<InviteCode> findByChallenge(Challenge challenge);
+    Optional<InviteCode> findByCode(String code);
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
@@ -2,11 +2,14 @@ package org.minu.dnd13th3backend.challenge.service;
 
 import lombok.RequiredArgsConstructor;
 import org.minu.dnd13th3backend.challenge.dto.request.ChallengeCreateRequest;
+import org.minu.dnd13th3backend.challenge.dto.request.InviteJoinRequest;
 import org.minu.dnd13th3backend.challenge.dto.response.ChallengeGetResponse;
 import org.minu.dnd13th3backend.challenge.entity.Challenge;
 import org.minu.dnd13th3backend.challenge.entity.ChallengeParticipant;
+import org.minu.dnd13th3backend.challenge.entity.InviteCode;
 import org.minu.dnd13th3backend.challenge.repository.ChallengeParticipantRepository;
 import org.minu.dnd13th3backend.challenge.repository.ChallengeRepository;
+import org.minu.dnd13th3backend.challenge.repository.InviteCodeRepository;
 import org.minu.dnd13th3backend.challenge.type.ChallengeStatus;
 import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 import org.minu.dnd13th3backend.common.exception.BusinessException;
@@ -14,11 +17,14 @@ import org.minu.dnd13th3backend.common.exception.ErrorCode;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
 import org.minu.dnd13th3backend.screentime.repository.ScreenTimeRepository;
 import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,7 +33,11 @@ public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
     private final ChallengeParticipantRepository participantRepository;
+    private final InviteCodeRepository inviteCodeRepository;
     private final ScreenTimeRepository screenTimeRepository;
+
+    @Value("${app.frontend.base-url}")
+    private String frontendBaseUrl;
 
     @Transactional
     public Challenge createChallenge(ChallengeCreateRequest request, User user) {
@@ -55,19 +65,17 @@ public class ChallengeService {
 
     @Transactional(readOnly = true)
     public ChallengeGetResponse getChallenge(ChallengeType type, LocalDate startDate, LocalDate endDate, User user) {
-
-        List<ChallengeParticipant> userParticipation;
+        Optional<ChallengeParticipant> userParticipation;
         if (startDate != null && endDate != null) {
-            userParticipation = participantRepository.findByUserAndChallenge_TypeAndChallenge_StartDateAndChallenge_EndDate(user, type, startDate, endDate);
+            userParticipation = participantRepository.findFirstByUserAndChallenge_TypeAndChallenge_StartDateAndChallenge_EndDateOrderByChallenge_CreatedAtDesc(user, type, startDate, endDate);
         } else {
             LocalDate today = LocalDate.now();
-            userParticipation = participantRepository.findByUserAndChallenge_TypeAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqual(user, type, today, today);
+            userParticipation = participantRepository.findFirstByUserAndChallenge_TypeAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqualOrderByChallenge_CreatedAtDesc(user, type, today, today);
         }
 
-        if (userParticipation.isEmpty()) {
-            throw new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND);
-        }
-        Challenge challenge = userParticipation.get(0).getChallenge();
+        Challenge challenge = userParticipation
+                .map(ChallengeParticipant::getChallenge)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND));
 
         List<ChallengeParticipant> allParticipants = participantRepository.findByChallenge_Id(challenge.getId());
 
@@ -79,13 +87,10 @@ public class ChallengeService {
                             participantUser.getId(), challenge.getStartDate(), challenge.getEndDate()
                     );
 
-                    long totalInsta = 0, totalYoutube = 0, totalKakaotalk = 0, totalChrome = 0;
-                    for (ScreenTime st : screenTimes) {
-                        totalInsta += st.getInstagramMinutes();
-                        totalYoutube += st.getYoutubeMinutes();
-                        totalKakaotalk += st.getKakaotalkMinutes();
-                        totalChrome += st.getChromeMinutes();
-                    }
+                    long totalInsta = screenTimes.stream().mapToLong(ScreenTime::getInstagramMinutes).sum();
+                    long totalYoutube = screenTimes.stream().mapToLong(ScreenTime::getYoutubeMinutes).sum();
+                    long totalKakaotalk = screenTimes.stream().mapToLong(ScreenTime::getKakaotalkMinutes).sum();
+                    long totalChrome = screenTimes.stream().mapToLong(ScreenTime::getChromeMinutes).sum();
                     long currentTimeMinutes = totalInsta + totalYoutube + totalKakaotalk + totalChrome;
 
                     double achievementRate;
@@ -126,5 +131,56 @@ public class ChallengeService {
                 .goalTimeMinutes(challenge.getGoalTimeMinutes())
                 .participants(participantRecords)
                 .build();
+    }
+
+    @Transactional
+    public String generateInviteLink(User user) {
+        Challenge challenge = challengeRepository.findTopByCreatorAndTypeOrderByCreatedAtDesc(user, ChallengeType.SHARE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+        InviteCode inviteCode = inviteCodeRepository.findByChallenge(challenge)
+                .orElseGet(() -> {
+                    InviteCode newCode = InviteCode.builder()
+                            .challenge(challenge)
+                            .code(UUID.randomUUID().toString().substring(0, 8))
+                            .expiresAt(challenge.getEndDate())
+                            .build();
+                    return inviteCodeRepository.save(newCode);
+                });
+
+        return frontendBaseUrl + "/join?code=" + inviteCode.getCode();
+    }
+
+    @Transactional
+    public Challenge joinChallenge(InviteJoinRequest request, User user) {
+        InviteCode inviteCode = inviteCodeRepository.findByCode(request.getInviteCode())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVITE_CODE_NOT_FOUND));
+
+        if (LocalDate.now().isAfter(inviteCode.getExpiresAt())) {
+            throw new BusinessException(ErrorCode.INVITE_CODE_EXPIRED);
+        }
+
+        Challenge challenge = inviteCode.getChallenge();
+
+        if (challenge.getCreator().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.CANNOT_JOIN_OWN_CHALLENGE);
+        }
+
+        if (participantRepository.existsByChallengeAndUser(challenge, user)) {
+            throw new BusinessException(ErrorCode.CHALLENGE_ALREADY_JOINED);
+        }
+
+        long currentParticipants = participantRepository.countByChallenge(challenge);
+        if (currentParticipants >= 6) {
+            throw new BusinessException(ErrorCode.CHALLENGE_FULL);
+        }
+
+        ChallengeParticipant participant = ChallengeParticipant.builder()
+                .challenge(challenge)
+                .user(user)
+                .build();
+        participantRepository.save(participant);
+
+        return challenge;
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
@@ -12,7 +12,12 @@ public enum ErrorCode {
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필을 찾을 수 없습니다."),
     PROFILE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 프로필이 존재합니다."),
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 챌린지를 찾을 수 없습니다."),
-    
+    INVITE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 초대 코드입니다."),
+    INVITE_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 초대 코드입니다."),
+    CHALLENGE_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 참여한 챌린지입니다."),
+    CHALLENGE_FULL(HttpStatus.BAD_REQUEST, "챌린지 인원이 가득 찼습니다."),
+    CANNOT_JOIN_OWN_CHALLENGE(HttpStatus.BAD_REQUEST, "본인이 생성한 챌린지에는 참여할 수 없습니다."),
+
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     


### PR DESCRIPTION
## 관련 이슈
#46 

## 작업 내용
- 공유 챌린지에 대해 초대 링크를 생성하고, 해당 링크에 대해 초대를 수락하는 api를 구현했습니다.
- 링크 생성 및 수락 과정에서 필요한 에러 타입을 생성했습니다.
- api 호출 시 생성되는 링크는 프론트엔드 배포 url/join?code=(랜덤값)으로 생성됩니다.
- 자세한 api 실행 방법은 api 명세서를 참고해주시면 감사하겠습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Create shareable invite links for challenges.
  * Join a challenge using an invite code; response includes challenge title, dates, and status message.
  * Clear validation and error messages for invalid/expired codes, full challenges, duplicate joins, and attempting to join your own challenge.
  * Participant cap enforced (up to 6 members) to maintain challenge limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->