### PR TITLE
feat: 로그인 시 신규/기존 사용자 구분 정보 추가

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/auth/controller/AuthController.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/controller/AuthController.java
@@ -36,7 +36,9 @@ public class AuthController {
         
         String frontendUrl = "http://localhost:3000/login/success" +
                 "?accessToken=" + tokenResponse.getAccessToken() +
-                "&refreshToken=" + tokenResponse.getRefreshToken();
+                "&refreshToken=" + tokenResponse.getRefreshToken() +
+                "&characterIndex=" + tokenResponse.getCharacterIndex() +
+                "&isNewUser=" + tokenResponse.getIsNewUser();
         
         return new RedirectView(frontendUrl);
     }
@@ -63,7 +65,8 @@ public class AuthController {
                                     {
                                       "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzU0Mjg3NTQ1LCJleHAiOjE3NTQyODkzNDV9...",
                                       "refreshToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzU0Mjg3NTQ1LCJleHAiOjE3NTQ4OTIzNDV9...",
-                                      "characterIndex": 3
+                                      "characterIndex": 3,
+                                      "isNewUser": false
                                     }
                                     """
                             )

--- a/src/main/java/org/minu/dnd13th3backend/auth/dto/TokenResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/dto/TokenResponse.java
@@ -30,7 +30,14 @@ public class TokenResponse {
     )
     private final Integer characterIndex;
     
-    public static TokenResponse of(String accessToken, String refreshToken, Integer characterIndex) {
-        return new TokenResponse(accessToken, refreshToken, characterIndex);
+    @Schema(
+            description = "신규 가입 사용자 여부 (true: 신규 가입, false: 기존 사용자)",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    private final Boolean isNewUser;
+    
+    public static TokenResponse of(String accessToken, String refreshToken, Integer characterIndex, Boolean isNewUser) {
+        return new TokenResponse(accessToken, refreshToken, characterIndex, isNewUser);
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/auth/service/AuthService.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/service/AuthService.java
@@ -38,8 +38,16 @@ public class AuthService {
             throw new BusinessException(HttpStatus.BAD_REQUEST, "필수 OAuth2 정보가 누락되었습니다.");
         }
 
+        // 기존 사용자인지 확인
+        boolean isNewUser = false;
         OauthInfo oauthInfo = oauthInfoRepository.findByOauthIdAndProvider(googleId, "google")
-                .orElseGet(() -> createNewUser(googleId, email, name));
+                .orElse(null);
+        
+        if (oauthInfo == null) {
+            // 신규 사용자 생성
+            oauthInfo = createNewUser(googleId, email, name);
+            isNewUser = true;
+        }
 
         User user = oauthInfo.getUser();
         String accessToken = jwtTokenProvider.createAccessToken(user.getId().toString());
@@ -49,7 +57,7 @@ public class AuthService {
         
         Integer characterIndex = generateRandomCharacterIndex();
 
-        return TokenResponse.of(accessToken, refreshToken, characterIndex);
+        return TokenResponse.of(accessToken, refreshToken, characterIndex, isNewUser);
     }
 
     private OauthInfo createNewUser(String googleId, String email, String name) {
@@ -88,7 +96,7 @@ public class AuthService {
         
         Integer characterIndex = generateRandomCharacterIndex();
 
-        return TokenResponse.of(newAccessToken, newRefreshToken, characterIndex);
+        return TokenResponse.of(newAccessToken, newRefreshToken, characterIndex, false);
     }
     
     public String getUserIdFromToken(String accessToken) {


### PR DESCRIPTION
## 관련 이슈
#77 

## 작업 내용
- TokenResponse에 isNewUser 필드 추가 (Boolean)
- AuthService에서 신규 사용자 생성 시 isNewUser=true 반환
- OAuth2 리다이렉트 URL에 isNewUser 파라미터 추가
- API 문서 업데이트 및 예시 추가

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OAuth sign-in redirect now includes characterIndex and isNewUser query parameters alongside refreshToken.
  - Token responses include an isNewUser flag (set on initial login; false on refresh).

- **Documentation**
  - API docs/examples updated to show the new isNewUser field in token responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->