### PR TITLE
fix: ScreenTimeAnalysisDto에서 개별 앱 사용시간 합산으로 변경

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/analyze/dto/ScreenTimeAnalysisDto.java
+++ b/src/main/java/org/minu/dnd13th3backend/analyze/dto/ScreenTimeAnalysisDto.java
@@ -28,13 +28,13 @@ public class ScreenTimeAnalysisDto {
         }
 
         int totalMinutes = screenTimes.stream()
-                .mapToInt(ScreenTime::getScreentimeMinutes)
+                .mapToInt(st -> st.getInstagramMinutes() + st.getYoutubeMinutes() + st.getKakaotalkMinutes() + st.getChromeMinutes())
                 .sum();
 
         double avgMinutes = (double) totalMinutes / 7;
         
         int maxMinutes = screenTimes.stream()
-                .mapToInt(ScreenTime::getScreentimeMinutes)
+                .mapToInt(st -> st.getInstagramMinutes() + st.getYoutubeMinutes() + st.getKakaotalkMinutes() + st.getChromeMinutes())
                 .max()
                 .orElse(0);
 


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- getScreentimeMinutes() 대신 개별 앱별 사용시간을 합산하도록 수정

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected screen time calculations to sum per-app usage (Instagram, YouTube, KakaoTalk, Chrome) per day, fixing underreported totals and peak daily minutes.
  - Weekly summaries now reflect accurate totals, averages (7-day), and comparisons on dashboards and reports.
  - Empty-week cases continue to be handled gracefully without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->