### PR TITLE
fix: GoalType과 ScreenTimeGoalType enum JSON 역직렬화 지원

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/user/type/GoalType.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/type/GoalType.java
@@ -1,0 +1,36 @@
+package org.minu.dnd13th3backend.user.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum GoalType {
+    FOCUS_IMPROVEMENT, 
+    SLEEP_REGULARITY, 
+    HEALTH_CARE, 
+    NO_SCREEN, 
+    CUSTOM;
+
+    @JsonCreator
+    public static GoalType fromString(String value) {
+        if (value == null) {
+            return null;
+        }
+        
+        switch (value) {
+            case "집중력을 높이고 산만함을 줄이고 싶어요":
+                return FOCUS_IMPROVEMENT;
+            case "수면 패턴을 개선하고 싶어요":
+                return SLEEP_REGULARITY;
+            case "건강 관리를 위해 스크린타임을 줄이고 싶어요":
+                return HEALTH_CARE;
+            case "스크린 없는 시간을 늘리고 싶어요":
+                return NO_SCREEN;
+            case "custom":
+                return CUSTOM;
+            default:
+                if (value.equals(value.toUpperCase())) {
+                    return GoalType.valueOf(value);
+                }
+                throw new IllegalArgumentException("Unknown GoalType: " + value);
+        }
+    }
+}

--- a/src/main/java/org/minu/dnd13th3backend/user/type/ScreenTimeGoalType.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/type/ScreenTimeGoalType.java
@@ -1,0 +1,52 @@
+package org.minu.dnd13th3backend.user.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum ScreenTimeGoalType {
+    TWO_HOURS("2HOURS", 120),
+    FOUR_HOURS("4HOURS", 240),
+    SIX_HOURS("6HOURS", 360),
+    EIGHT_HOURS("8HOURS", 480),
+    CUSTOM("CUSTOM", 0);
+
+    private final String value;
+    private final int minutes;
+
+    ScreenTimeGoalType(String value, int minutes) {
+        this.value = value;
+        this.minutes = minutes;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public int getMinutes() {
+        return minutes;
+    }
+
+    @JsonCreator
+    public static ScreenTimeGoalType fromString(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        switch (value) {
+            case "2HOURS":
+                return TWO_HOURS;
+            case "4HOURS":
+                return FOUR_HOURS;
+            case "6HOURS":
+                return SIX_HOURS;
+            case "8HOURS":
+                return EIGHT_HOURS;
+            case "custom":
+                return CUSTOM;
+            default:
+                if (value.equals(value.toUpperCase())) {
+                    return ScreenTimeGoalType.valueOf(value);
+                }
+                return CUSTOM;
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
#81 

## 작업 내용
- GoalType에 @JsonCreator 추가하여 한글 텍스트를 enum으로 매핑
- ScreenTimeGoalType에 @JsonCreator 추가하여 문자열 값 처리
- custom 값들도 적절한 enum으로 매핑되도록 처리

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new goal categories: focus improvement, sleep regularity, health care, more screen-free time, and custom.
  * Introduced screen time presets (2h, 4h, 6h, 8h) with explicit duration support.

* **Improvements**
  * Enhanced goal parsing to accept localized Korean phrases and flexible uppercase inputs for smoother goal selection and deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->