### PR TITLE
fix: screenTimeGoal enum 매핑 값 변경

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/user/type/ScreenTimeGoalType.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/type/ScreenTimeGoalType.java
@@ -34,13 +34,13 @@ public enum ScreenTimeGoalType {
         }
 
         switch (value) {
-            case "2HOURS":
+            case "120":
                 return TWO_HOURS;
-            case "4HOURS":
+            case "240":
                 return FOUR_HOURS;
-            case "6HOURS":
+            case "360":
                 return SIX_HOURS;
-            case "8HOURS":
+            case "480":
                 return EIGHT_HOURS;
             case "custom":
                 return CUSTOM;


### PR DESCRIPTION
## 관련 이슈
#81 
## 작업 내용
- 목표 타임 enum 매핑 값 변경
## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Screen time goals now accept minute-based inputs for common presets (120, 240, 360, 480), improving compatibility with numeric selections.
  - Custom goal handling remains supported for non-standard durations.

- Bug Fixes
  - Improved interpretation of screen time goal values to reduce input mismatches and ensure consistent selection across presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->