### PR TITLE
fix: 챌린지 관련 기능 수정

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
@@ -3,13 +3,9 @@ package org.minu.dnd13th3backend.challenge.controller;
 import lombok.RequiredArgsConstructor;
 import org.minu.dnd13th3backend.challenge.dto.request.ChallengeCreateRequest;
 import org.minu.dnd13th3backend.challenge.dto.request.InviteJoinRequest;
-import org.minu.dnd13th3backend.challenge.dto.response.ChallengeCreateResponse;
-import org.minu.dnd13th3backend.challenge.dto.response.ChallengeGetResponse;
-import org.minu.dnd13th3backend.challenge.dto.response.InviteJoinResponse;
-import org.minu.dnd13th3backend.challenge.dto.response.InviteUrlCreateResponse;
+import org.minu.dnd13th3backend.challenge.dto.response.*;
 import org.minu.dnd13th3backend.challenge.entity.Challenge;
 import org.minu.dnd13th3backend.challenge.service.ChallengeService;
-import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 import org.minu.dnd13th3backend.common.dto.ResponseDto;
 import org.minu.dnd13th3backend.user.entity.User;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -39,21 +35,29 @@ public class ChallengeController {
     }
 
     @GetMapping
-    public ResponseEntity<ResponseDto<ChallengeGetResponse>> getChallenge(
-            @RequestParam("type") ChallengeType type,
+    public ResponseEntity<ResponseDto<ChallengeListResponse>> getChallenges(
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @AuthenticationPrincipal User user
     ) {
-        ChallengeGetResponse responseData = challengeService.getChallenge(type, startDate, endDate, user);
+        ChallengeListResponse responseData = challengeService.getChallenges(startDate, endDate, user);
+
+        if (responseData.getChallenges().isEmpty()) {
+            String message = (startDate != null && endDate != null) ?
+                    "해당 기간에 완료된 챌린지가 없습니다." :
+                    "참여 중인 챌린지가 없습니다.";
+            return ResponseEntity.ok(ResponseDto.success(message, responseData));
+        }
+
         return ResponseEntity.ok(ResponseDto.success("챌린지 조회가 성공했습니다.", responseData));
     }
 
-    @PostMapping("/inviteUrl")
+    @PostMapping("/inviteUrl/{challengeId}")
     public ResponseEntity<ResponseDto<InviteUrlCreateResponse>> createInviteUrl(
+            @PathVariable Long challengeId,
             @AuthenticationPrincipal User user
     ) {
-        String url = challengeService.generateInviteLink(user);
+        String url = challengeService.generateInviteLink(challengeId, user);
         InviteUrlCreateResponse response = new InviteUrlCreateResponse(url);
         return ResponseEntity.ok(ResponseDto.success("초대 링크가 성공적으로 생성되었습니다.", response));
     }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/ChallengeCreateRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/request/ChallengeCreateRequest.java
@@ -3,7 +3,6 @@ package org.minu.dnd13th3backend.challenge.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 
 import java.time.LocalDate;
 
@@ -19,8 +18,6 @@ public class ChallengeCreateRequest {
 
     @JsonProperty("goal_time_minutes")
     private int goalTimeMinutes;
-
-    private ChallengeType type;
 
     private String title;
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeGetResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeGetResponse.java
@@ -3,7 +3,6 @@ package org.minu.dnd13th3backend.challenge.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
-import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,7 +12,6 @@ import java.util.List;
 public class ChallengeGetResponse {
 
     private Long challengeId;
-    private ChallengeType type;
 
     @JsonProperty("start_date")
     private LocalDate startDate;

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeListResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeListResponse.java
@@ -1,0 +1,4 @@
+package org.minu.dnd13th3backend.challenge.dto.response;
+
+public class ChallengeListResponse {
+}

--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeListResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeListResponse.java
@@ -1,4 +1,12 @@
 package org.minu.dnd13th3backend.challenge.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
 public class ChallengeListResponse {
+    private List<ChallengeGetResponse> challenges;
 }

--- a/src/main/java/org/minu/dnd13th3backend/challenge/entity/Challenge.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/entity/Challenge.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.minu.dnd13th3backend.challenge.type.ChallengeStatus;
-import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 import org.minu.dnd13th3backend.user.entity.User;
 
 import java.time.LocalDate;
@@ -30,9 +29,6 @@ public class Challenge {
     @Column(length = 100)
     private String title;
 
-    @Enumerated(EnumType.STRING)
-    private ChallengeType type;
-
     private int goalTimeMinutes;
 
     private LocalDate startDate;
@@ -49,10 +45,9 @@ public class Challenge {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Challenge(User creator, String title, ChallengeType type, int goalTimeMinutes, LocalDate startDate, LocalDate endDate, ChallengeStatus status) {
+    public Challenge(User creator, String title, int goalTimeMinutes, LocalDate startDate, LocalDate endDate, ChallengeStatus status) {
         this.creator = creator;
         this.title = title;
-        this.type = type;
         this.goalTimeMinutes = goalTimeMinutes;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
@@ -2,7 +2,6 @@ package org.minu.dnd13th3backend.challenge.repository;
 
 import org.minu.dnd13th3backend.challenge.entity.Challenge;
 import org.minu.dnd13th3backend.challenge.entity.ChallengeParticipant;
-import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 import org.minu.dnd13th3backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,12 +13,12 @@ import java.util.Optional;
 @Repository
 public interface ChallengeParticipantRepository extends JpaRepository<ChallengeParticipant, Long> {
 
-    Optional<ChallengeParticipant> findFirstByUserAndChallenge_TypeAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqualOrderByChallenge_CreatedAtDesc(
-            User user, ChallengeType type, LocalDate today1, LocalDate today2
+    List<ChallengeParticipant> findByUserAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqualOrderByChallenge_CreatedAtDesc(
+            User user, LocalDate today1, LocalDate today2
     );
 
-    Optional<ChallengeParticipant> findFirstByUserAndChallenge_TypeAndChallenge_StartDateAndChallenge_EndDateOrderByChallenge_CreatedAtDesc(
-            User user, ChallengeType type, LocalDate startDate, LocalDate endDate
+    List<ChallengeParticipant> findByUserAndChallenge_StartDateAndChallenge_EndDateOrderByChallenge_CreatedAtDesc(
+            User user, LocalDate startDate, LocalDate endDate
     );
 
     List<ChallengeParticipant> findByChallenge_Id(Long challengeId);

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeRepository.java
@@ -1,7 +1,6 @@
 package org.minu.dnd13th3backend.challenge.repository;
 
 import org.minu.dnd13th3backend.challenge.entity.Challenge;
-import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 import org.minu.dnd13th3backend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,6 +10,6 @@ import java.util.Optional;
 @Repository
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
-    Optional<Challenge> findTopByCreatorAndTypeOrderByCreatedAtDesc(User creator, ChallengeType type);
+    Optional<Challenge> findTopByCreatorOrderByCreatedAtDesc(User creator);
 }
 

--- a/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.minu.dnd13th3backend.challenge.dto.request.ChallengeCreateRequest;
 import org.minu.dnd13th3backend.challenge.dto.request.InviteJoinRequest;
 import org.minu.dnd13th3backend.challenge.dto.response.ChallengeGetResponse;
+import org.minu.dnd13th3backend.challenge.dto.response.ChallengeListResponse;
 import org.minu.dnd13th3backend.challenge.entity.Challenge;
 import org.minu.dnd13th3backend.challenge.entity.ChallengeParticipant;
 import org.minu.dnd13th3backend.challenge.entity.InviteCode;
@@ -11,7 +12,6 @@ import org.minu.dnd13th3backend.challenge.repository.ChallengeParticipantReposit
 import org.minu.dnd13th3backend.challenge.repository.ChallengeRepository;
 import org.minu.dnd13th3backend.challenge.repository.InviteCodeRepository;
 import org.minu.dnd13th3backend.challenge.type.ChallengeStatus;
-import org.minu.dnd13th3backend.challenge.type.ChallengeType;
 import org.minu.dnd13th3backend.common.exception.BusinessException;
 import org.minu.dnd13th3backend.common.exception.ErrorCode;
 import org.minu.dnd13th3backend.screentime.entity.ScreenTime;
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -44,7 +43,6 @@ public class ChallengeService {
         Challenge challenge = Challenge.builder()
                 .creator(user)
                 .title(request.getTitle())
-                .type(request.getType())
                 .goalTimeMinutes(request.getGoalTimeMinutes())
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
@@ -64,79 +62,89 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public ChallengeGetResponse getChallenge(ChallengeType type, LocalDate startDate, LocalDate endDate, User user) {
-        Optional<ChallengeParticipant> userParticipation;
+    public ChallengeListResponse getChallenges(LocalDate startDate, LocalDate endDate, User user) {
+
+        List<ChallengeParticipant> userParticipations;
         if (startDate != null && endDate != null) {
-            userParticipation = participantRepository.findFirstByUserAndChallenge_TypeAndChallenge_StartDateAndChallenge_EndDateOrderByChallenge_CreatedAtDesc(user, type, startDate, endDate);
+            userParticipations = participantRepository.findByUserAndChallenge_StartDateAndChallenge_EndDateOrderByChallenge_CreatedAtDesc(user, startDate, endDate);
         } else {
             LocalDate today = LocalDate.now();
-            userParticipation = participantRepository.findFirstByUserAndChallenge_TypeAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqualOrderByChallenge_CreatedAtDesc(user, type, today, today);
+            userParticipations = participantRepository.findByUserAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqualOrderByChallenge_CreatedAtDesc(user, today, today);
         }
 
-        Challenge challenge = userParticipation
-                .map(ChallengeParticipant::getChallenge)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND));
+        if (userParticipations.isEmpty()) {
+            return ChallengeListResponse.builder().challenges(List.of()).build();
+        }
 
-        List<ChallengeParticipant> allParticipants = participantRepository.findByChallenge_Id(challenge.getId());
+        List<ChallengeGetResponse> challengeResponses = userParticipations.stream()
+                .map(participation -> {
+                    Challenge challenge = participation.getChallenge();
+                    List<ChallengeParticipant> allParticipants = participantRepository.findByChallenge_Id(challenge.getId());
 
-        List<ChallengeGetResponse.ParticipantRecord> participantRecords = allParticipants.stream()
-                .map(participant -> {
-                    User participantUser = participant.getUser();
+                    List<ChallengeGetResponse.ParticipantRecord> participantRecords = allParticipants.stream()
+                            .map(participant -> {
+                                User participantUser = participant.getUser();
+                                List<ScreenTime> screenTimes = screenTimeRepository.findByUser_IdAndDateBetween(
+                                        participantUser.getId(), challenge.getStartDate(), challenge.getEndDate()
+                                );
 
-                    List<ScreenTime> screenTimes = screenTimeRepository.findByUser_IdAndDateBetween(
-                            participantUser.getId(), challenge.getStartDate(), challenge.getEndDate()
-                    );
+                                long totalInsta = screenTimes.stream().mapToLong(ScreenTime::getInstagramMinutes).sum();
+                                long totalYoutube = screenTimes.stream().mapToLong(ScreenTime::getYoutubeMinutes).sum();
+                                long totalKakaotalk = screenTimes.stream().mapToLong(ScreenTime::getKakaotalkMinutes).sum();
+                                long totalChrome = screenTimes.stream().mapToLong(ScreenTime::getChromeMinutes).sum();
+                                long currentTimeMinutes = totalInsta + totalYoutube + totalKakaotalk + totalChrome;
 
-                    long totalInsta = screenTimes.stream().mapToLong(ScreenTime::getInstagramMinutes).sum();
-                    long totalYoutube = screenTimes.stream().mapToLong(ScreenTime::getYoutubeMinutes).sum();
-                    long totalKakaotalk = screenTimes.stream().mapToLong(ScreenTime::getKakaotalkMinutes).sum();
-                    long totalChrome = screenTimes.stream().mapToLong(ScreenTime::getChromeMinutes).sum();
-                    long currentTimeMinutes = totalInsta + totalYoutube + totalKakaotalk + totalChrome;
+                                double achievementRate;
+                                if (challenge.getGoalTimeMinutes() > 0) {
+                                    double usageRate = ((double) currentTimeMinutes / challenge.getGoalTimeMinutes()) * 100.0;
+                                    achievementRate = Math.max(0, 100.0 - usageRate);
+                                } else {
+                                    achievementRate = (currentTimeMinutes == 0) ? 100.0 : 0.0;
+                                }
 
-                    double achievementRate;
-                    if (challenge.getGoalTimeMinutes() > 0) {
-                        double usageRate = ((double) currentTimeMinutes / challenge.getGoalTimeMinutes()) * 100.0;
-                        achievementRate = Math.max(0, 100.0 - usageRate);
-                    } else {
-                        achievementRate = (currentTimeMinutes == 0) ? 100.0 : 0.0;
-                    }
+                                String status;
+                                if (LocalDate.now().isAfter(challenge.getEndDate())) {
+                                    status = (currentTimeMinutes <= challenge.getGoalTimeMinutes()) ? "달성" : "실패";
+                                } else {
+                                    status = "진행 중";
+                                }
 
-                    String status;
-                    if (LocalDate.now().isAfter(challenge.getEndDate())) {
-                        status = (currentTimeMinutes <= challenge.getGoalTimeMinutes()) ? "달성" : "실패";
-                    } else {
-                        status = "진행 중";
-                    }
+                                return ChallengeGetResponse.ParticipantRecord.builder()
+                                        .userId(participantUser.getId())
+                                        .nickname(participantUser.getProfile().getNickname())
+                                        .currentTimeMinutes(currentTimeMinutes)
+                                        .instagramMinutes(totalInsta)
+                                        .youtubeMinutes(totalYoutube)
+                                        .kakaotalkMinutes(totalKakaotalk)
+                                        .chromeMinutes(totalChrome)
+                                        .achievementRate(achievementRate)
+                                        .status(status)
+                                        .build();
+                            })
+                            .collect(Collectors.toList());
 
-                    return ChallengeGetResponse.ParticipantRecord.builder()
-                            .userId(participantUser.getId())
-                            .nickname(participantUser.getProfile().getNickname())
-                            .currentTimeMinutes(currentTimeMinutes)
-                            .instagramMinutes(totalInsta)
-                            .youtubeMinutes(totalYoutube)
-                            .kakaotalkMinutes(totalKakaotalk)
-                            .chromeMinutes(totalChrome)
-                            .achievementRate(achievementRate)
-                            .status(status)
+                    return ChallengeGetResponse.builder()
+                            .challengeId(challenge.getId())
+                            .startDate(challenge.getStartDate())
+                            .endDate(challenge.getEndDate())
+                            .title(challenge.getTitle())
+                            .goalTimeMinutes(challenge.getGoalTimeMinutes())
+                            .participants(participantRecords)
                             .build();
                 })
                 .collect(Collectors.toList());
 
-        return ChallengeGetResponse.builder()
-                .challengeId(challenge.getId())
-                .type(challenge.getType())
-                .startDate(challenge.getStartDate())
-                .endDate(challenge.getEndDate())
-                .title(challenge.getTitle())
-                .goalTimeMinutes(challenge.getGoalTimeMinutes())
-                .participants(participantRecords)
-                .build();
+        return ChallengeListResponse.builder().challenges(challengeResponses).build();
     }
 
     @Transactional
-    public String generateInviteLink(User user) {
-        Challenge challenge = challengeRepository.findTopByCreatorAndTypeOrderByCreatedAtDesc(user, ChallengeType.SHARE)
+    public String generateInviteLink(Long challengeId, User user) {
+        Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+        if (!challenge.getCreator().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
 
         InviteCode inviteCode = inviteCodeRepository.findByChallenge(challenge)
                 .orElseGet(() -> {

--- a/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeType.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/type/ChallengeType.java
@@ -1,6 +1,0 @@
-package org.minu.dnd13th3backend.challenge.type;
-
-public enum ChallengeType {
-    PERSONAL,
-    SHARE
-}

--- a/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     CHALLENGE_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 참여한 챌린지입니다."),
     CHALLENGE_FULL(HttpStatus.BAD_REQUEST, "챌린지 인원이 가득 찼습니다."),
     CANNOT_JOIN_OWN_CHALLENGE(HttpStatus.BAD_REQUEST, "본인이 생성한 챌린지에는 참여할 수 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,3 +9,7 @@ spring:
 app:
   frontend:
     base-url: http://localhost:3000
+
+gemini:
+  api:
+    key: "AIzaSyD84j8iIE-2_DRpIFuT3qhCmd7inLCZjUQ"


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 챌린지의 개인/공유 타입을 제거함으로서 구분 없이 챌린지를 생성/조회할 수 있도록 수정하였습니다.
- 수정에 따라 챌린지 조회 시 params에 type을 넣지 않고 요청할 수 있습니다.
- 챌린지 타입 제거에 따라 챌린지 초대 코드 생성 시 챌린지 구분을 하기 위해 챌린지 id를 parmams에 포함하여 보내도록 수정하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Retrieve challenges as a list with optional startDate/endDate filters.
  - Clear empty-state messages: none in range or none in progress.
  - Generate invite links per specific challenge via /api/challenge/inviteUrl/{challengeId}.
  - Permission enforcement on invite link creation with proper 403 response.
- Changes
  - Challenge type removed from requests and responses; unified challenge model.
  - GET challenge endpoint renamed and now returns a list response.
  - Invite URL endpoint now requires a challengeId path parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->