### PR TITLE
feat: 프로필 수정 및 조회 기능에서 닉네임, 캐릭터 인덱스 지원 추가

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/auth/service/AuthService.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/service/AuthService.java
@@ -4,15 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.minu.dnd13th3backend.auth.dto.TokenResponse;
 import org.minu.dnd13th3backend.common.exception.BusinessException;
 import org.minu.dnd13th3backend.user.entity.OauthInfo;
+import org.minu.dnd13th3backend.user.entity.Profile;
 import org.minu.dnd13th3backend.user.entity.User;
 import org.minu.dnd13th3backend.user.repository.OauthInfoRepository;
+import org.minu.dnd13th3backend.user.repository.ProfileRepository;
 import org.minu.dnd13th3backend.user.repository.UserRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -21,9 +21,9 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final OauthInfoRepository oauthInfoRepository;
+    private final ProfileRepository profileRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
-    private final Random random = new Random();
 
     public TokenResponse processOAuth2Login(OAuth2User oauth2User) {
         if (oauth2User == null) {
@@ -55,7 +55,13 @@ public class AuthService {
         
         refreshTokenService.storeRefreshToken(user.getId().toString(), refreshToken);
         
-        Integer characterIndex = generateRandomCharacterIndex();
+        Integer characterIndex = null;
+        if (!isNewUser) {
+            Profile profile = profileRepository.findById(user.getId()).orElse(null);
+            if (profile != null) {
+                characterIndex = profile.getCharacterIndex();
+            }
+        }
 
         return TokenResponse.of(accessToken, refreshToken, characterIndex, isNewUser);
     }
@@ -94,7 +100,11 @@ public class AuthService {
         
         refreshTokenService.storeRefreshToken(user.getId().toString(), newRefreshToken);
         
-        Integer characterIndex = generateRandomCharacterIndex();
+        Integer characterIndex = null;
+        Profile profile = profileRepository.findById(user.getId()).orElse(null);
+        if (profile != null) {
+            characterIndex = profile.getCharacterIndex();
+        }
 
         return TokenResponse.of(newAccessToken, newRefreshToken, characterIndex, false);
     }
@@ -104,9 +114,5 @@ public class AuthService {
             throw new BusinessException(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다.");
         }
         return jwtTokenProvider.getSubject(accessToken);
-    }
-    
-    private Integer generateRandomCharacterIndex() {
-        return random.nextInt(6) + 1;
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/user/controller/ProfileController.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/controller/ProfileController.java
@@ -146,8 +146,8 @@ public class ProfileController {
         String accessToken = authHeader.replace("Bearer ", "");
         String userId = authService.getUserIdFromToken(accessToken);
         
-        profileService.createProfile(Long.valueOf(userId), request);
-        return ResponseEntity.ok(ProfileResponse.success("프로필이 성공적으로 등록되었습니다."));
+        Integer characterIndex = profileService.createProfile(Long.valueOf(userId), request);
+        return ResponseEntity.ok(ProfileResponse.success("프로필이 성공적으로 등록되었습니다.", characterIndex));
     }
 
     @Operation(

--- a/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
@@ -14,6 +14,13 @@ import org.minu.dnd13th3backend.user.type.ScreenTimeGoalType;
 @Schema(description = "프로필 수정 요청")
 public class ProfileUpdateRequest {
 
+    @Size(max = 30, message = "닉네임은 30자 이하여야 합니다")
+    @Schema(description = "사용자 닉네임", example = "종훈", maxLength = 30)
+    private String nickname;
+
+    @Schema(description = "캐릭터 인덱스", example = "1")
+    private Integer characterIndex;
+
     @Valid
     @NotNull(message = "목표는 필수입니다")
     @Schema(description = "목표 정보")

--- a/src/main/java/org/minu/dnd13th3backend/user/dto/response/ProfileDetailResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/response/ProfileDetailResponse.java
@@ -17,6 +17,9 @@ public class ProfileDetailResponse {
     @Schema(description = "사용자 닉네임", example = "종훈")
     private String nickname;
 
+    @Schema(description = "캐릭터 인덱스", example = "1")
+    private Integer characterIndex;
+
     @Schema(description = "목표 정보")
     private Goal goal;
 
@@ -49,6 +52,7 @@ public class ProfileDetailResponse {
         return ProfileDetailResponse.builder()
                 .id(profile.getUserId().toString())
                 .nickname(profile.getNickname())
+                .characterIndex(profile.getCharacterIndex())
                 .goal(Goal.builder()
                         .type(profile.getGoalType())
                         .custom(profile.getGoalCustom())

--- a/src/main/java/org/minu/dnd13th3backend/user/dto/response/ProfileResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/response/ProfileResponse.java
@@ -11,8 +11,15 @@ public class ProfileResponse {
 
     @Schema(description = "응답 메시지", example = "프로필이 성공적으로 등록되었습니다.")
     private String message;
+    
+    @Schema(description = "캐릭터 인덱스", example = "3")
+    private Integer characterIndex;
 
     public static ProfileResponse success(String message) {
-        return new ProfileResponse(message);
+        return new ProfileResponse(message, null);
+    }
+    
+    public static ProfileResponse success(String message, Integer characterIndex) {
+        return new ProfileResponse(message, characterIndex);
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/user/entity/Profile.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/entity/Profile.java
@@ -40,24 +40,30 @@ public class Profile {
     @Column(name = "screen_time_goal_custom", length = 100)
     private String screenTimeGoalCustom;
 
+    @Column(name = "character_index")
+    private Integer characterIndex;
 
     @Builder
     private Profile(User user, String nickname, GoalType goalType, String goalCustom,
-                   ScreenTimeGoalType screenTimeGoalType, String screenTimeGoalCustom) {
+                   ScreenTimeGoalType screenTimeGoalType, String screenTimeGoalCustom, 
+                   Integer characterIndex) {
         this.user = user;
         this.nickname = nickname;
         this.goalType = goalType;
         this.goalCustom = goalCustom;
         this.screenTimeGoalType = screenTimeGoalType;
         this.screenTimeGoalCustom = screenTimeGoalCustom;
+        this.characterIndex = characterIndex;
     }
 
     public void updateProfile(String nickname, GoalType goalType, String goalCustom,
-                             ScreenTimeGoalType screenTimeGoalType, String screenTimeGoalCustom) {
+                             ScreenTimeGoalType screenTimeGoalType, String screenTimeGoalCustom,
+                             Integer characterIndex) {
         this.nickname = nickname;
         this.goalType = goalType;
         this.goalCustom = goalCustom;
         this.screenTimeGoalType = screenTimeGoalType;
         this.screenTimeGoalCustom = screenTimeGoalCustom;
+        this.characterIndex = characterIndex;
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/user/service/ProfileService.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/service/ProfileService.java
@@ -13,6 +13,8 @@ import org.minu.dnd13th3backend.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Random;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,6 +22,7 @@ public class ProfileService {
 
     private final ProfileRepository profileRepository;
     private final UserRepository userRepository;
+    private final Random random = new Random();
 
     public ProfileDetailResponse getProfile(Long userId) {
         Profile profile = profileRepository.findById(userId)
@@ -29,7 +32,7 @@ public class ProfileService {
     }
 
     @Transactional
-    public void createProfile(Long userId, ProfileRequest request) {
+    public Integer createProfile(Long userId, ProfileRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -37,9 +40,12 @@ public class ProfileService {
             throw new BusinessException(ErrorCode.PROFILE_ALREADY_EXISTS);
         }
 
+        Integer characterIndex = generateRandomCharacterIndex();
+        
         Profile profile = Profile.builder()
                 .user(user)
                 .nickname(request.getNickname())
+                .characterIndex(characterIndex)
                 .goalType(request.getGoalType())
                 .goalCustom(request.getGoalCustom())
                 .screenTimeGoalType(request.getScreenTimeGoalType())
@@ -47,6 +53,7 @@ public class ProfileService {
                 .build();
 
         profileRepository.save(profile);
+        return characterIndex;
     }
 
     @Transactional
@@ -54,13 +61,21 @@ public class ProfileService {
         Profile profile = profileRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PROFILE_NOT_FOUND));
 
+        String nickname = request.getNickname() != null ? request.getNickname() : profile.getNickname();
+        Integer characterIndex = request.getCharacterIndex() != null ? request.getCharacterIndex() : profile.getCharacterIndex();
+
         profile.updateProfile(
-                profile.getNickname(),
+                nickname,
                 request.getGoalType(),
                 request.getGoalCustom(),
                 request.getScreenTimeGoalType(),
-                request.getScreenTimeGoalCustom()
+                request.getScreenTimeGoalCustom(),
+                characterIndex
         );
+    }
+    
+    private Integer generateRandomCharacterIndex() {
+        return random.nextInt(6) + 1;
     }
 
 }


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- Profile 엔티티에 characterIndex 필드 추가
- 프로필 수정 시 닉네임과 캐릭터 인덱스 변경 가능
- 프로필 조회 시 캐릭터 인덱스 포함하여 반환
- 프로필 등록 시 랜덤 캐릭터 인덱스 자동 생성 및 응답에 포함
- 로그인 시 기존 유저는 저장된 캐릭터 인덱스, 신규 유저는 null 반환

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Profiles now store and return a characterIndex; included in profile detail and creation responses.
  - Profile creation assigns a random characterIndex (1–6) and returns it in the API response.
  - Profile update supports changing nickname and characterIndex while preserving existing values if omitted.
  - OAuth login and token refresh now reflect the user’s saved characterIndex.

- Documentation
  - API docs updated to include characterIndex in request/response models and examples for profile operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->