### PR TITLE
add: 스크린타임 조회 시 상태값 및 요일 정보 추가

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetDailyResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetDailyResponse.java
@@ -11,26 +11,44 @@ import java.util.List;
 public class ScreenTimeGetDailyResponse {
     private List<DailyScreenTime> screenTimes;
 
-    public static ScreenTimeGetDailyResponse from(ScreenTime screenTime) {
+    public static ScreenTimeGetDailyResponse from(ScreenTime screenTime, String status) {
         if (screenTime == null) {
-            return ScreenTimeGetDailyResponse.builder().screenTimes(List.of()).build();
+            return ScreenTimeGetDailyResponse.builder()
+                    .screenTimes(List.of(DailyScreenTime.empty(LocalDate.now(), "NO_DATA")))
+                    .build();
         }
         return ScreenTimeGetDailyResponse.builder()
-                .screenTimes(List.of(new DailyScreenTime(screenTime)))
+                .screenTimes(List.of(new DailyScreenTime(screenTime, status)))
                 .build();
     }
 
     @Getter
     public static class DailyScreenTime {
         private LocalDate date;
+        private String dayOfWeek;
         private int totalMinutes;
+        private String status;
         private AppTimeDetails appTimes;
 
-        public DailyScreenTime(ScreenTime screenTime) {
+        public DailyScreenTime(ScreenTime screenTime, String status) {
             this.date = screenTime.getDate();
+            this.dayOfWeek = screenTime.getDate().getDayOfWeek().name(); // MONDAY, TUESDAY ...
             this.totalMinutes = screenTime.getInstagramMinutes() + screenTime.getYoutubeMinutes() +
                     screenTime.getKakaotalkMinutes() + screenTime.getChromeMinutes();
+            this.status = status;
             this.appTimes = new AppTimeDetails(screenTime);
+        }
+
+        public static DailyScreenTime empty(LocalDate date, String status) {
+            return new DailyScreenTime(date, status);
+        }
+
+        private DailyScreenTime(LocalDate date, String status) {
+            this.date = date;
+            this.dayOfWeek = date.getDayOfWeek().name();
+            this.totalMinutes = 0;
+            this.status = status;
+            this.appTimes = new AppTimeDetails(null);
         }
     }
 

--- a/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetWeeklyResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/dto/response/ScreenTimeGetWeeklyResponse.java
@@ -29,7 +29,9 @@ public class ScreenTimeGetWeeklyResponse {
     @Builder
     public static class DailyRecord {
         private LocalDate date;
+        private String dayOfWeek;
         private int totalMinutes;
+        private String status;
         private AppTimeDetails appTimes;
     }
 }

--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -129,13 +129,28 @@ public class ScreenTimeService {
     private ScreenTimeGetDailyResponse getDailyScreenTime(LocalDate date, User user) {
         LocalDate targetDate = (date == null) ? LocalDate.now() : date;
         ScreenTime screenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), targetDate).orElse(null);
-        return ScreenTimeGetDailyResponse.from(screenTime);
+
+        Profile profile = profileRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new IllegalStateException("해당 사용자의 프로필을 찾을 수 없습니다: " + user.getId()));
+        int goalMinutes = getGoalMinutes(profile);
+
+        String status = "NO_DATA";
+        if (screenTime != null) {
+            int totalMinutes = screenTime.getInstagramMinutes() + screenTime.getYoutubeMinutes() + screenTime.getKakaotalkMinutes() + screenTime.getChromeMinutes();
+            status = (totalMinutes > goalMinutes) ? "OVER" : "UNDER";
+        }
+
+        return ScreenTimeGetDailyResponse.from(screenTime, status);
     }
 
     private ScreenTimeGetWeeklyResponse getWeeklyScreenTime(LocalDate date, User user) {
         LocalDate today = (date == null) ? LocalDate.now() : date;
         LocalDate startOfWeek = today.with(DayOfWeek.MONDAY);
         LocalDate endOfWeek = today.with(DayOfWeek.SUNDAY);
+
+        Profile profile = profileRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new IllegalStateException("해당 사용자의 프로필을 찾을 수 없습니다: " + user.getId()));
+        int goalMinutes = getGoalMinutes(profile);
 
         List<ScreenTime> recordedTimes = screenTimeRepository.findByUser_IdAndDateBetween(user.getId(), startOfWeek, endOfWeek);
         Map<LocalDate, ScreenTime> recordedMap = recordedTimes.stream().collect(Collectors.toMap(ScreenTime::getDate, st -> st));
@@ -145,29 +160,36 @@ public class ScreenTimeService {
 
         for (LocalDate d = startOfWeek; !d.isAfter(endOfWeek); d = d.plusDays(1)) {
             ScreenTime st = recordedMap.get(d);
+            String status = "NO_DATA";
+            int dailyTotal = 0;
+
+            ScreenTimeGetWeeklyResponse.AppTimeDetails appTimes;
+
             if (st != null) {
+                dailyTotal = st.getInstagramMinutes() + st.getYoutubeMinutes() + st.getKakaotalkMinutes() + st.getChromeMinutes();
+                status = (dailyTotal > goalMinutes) ? "OVER" : "UNDER";
                 totalInsta += st.getInstagramMinutes();
                 totalYoutube += st.getYoutubeMinutes();
                 totalKakaotalk += st.getKakaotalkMinutes();
                 totalChrome += st.getChromeMinutes();
-
-                dailyRecords.add(ScreenTimeGetWeeklyResponse.DailyRecord.builder()
-                        .date(d)
-                        .totalMinutes(st.getInstagramMinutes() + st.getYoutubeMinutes() + st.getKakaotalkMinutes() + st.getChromeMinutes())
-                        .appTimes(ScreenTimeGetWeeklyResponse.AppTimeDetails.builder()
-                                .instagram(st.getInstagramMinutes())
-                                .youtube(st.getYoutubeMinutes())
-                                .kakaotalk(st.getKakaotalkMinutes())
-                                .chrome(st.getChromeMinutes())
-                                .build())
-                        .build());
+                appTimes = ScreenTimeGetWeeklyResponse.AppTimeDetails.builder()
+                        .instagram(st.getInstagramMinutes())
+                        .youtube(st.getYoutubeMinutes())
+                        .kakaotalk(st.getKakaotalkMinutes())
+                        .chrome(st.getChromeMinutes())
+                        .build();
             } else {
-                dailyRecords.add(ScreenTimeGetWeeklyResponse.DailyRecord.builder()
-                        .date(d)
-                        .totalMinutes(0)
-                        .appTimes(ScreenTimeGetWeeklyResponse.AppTimeDetails.builder().instagram(0).youtube(0).kakaotalk(0).chrome(0).build())
-                        .build());
+                appTimes = ScreenTimeGetWeeklyResponse.AppTimeDetails.builder()
+                        .instagram(0).youtube(0).kakaotalk(0).chrome(0).build();
             }
+
+            dailyRecords.add(ScreenTimeGetWeeklyResponse.DailyRecord.builder()
+                    .date(d)
+                    .dayOfWeek(d.getDayOfWeek().name())
+                    .totalMinutes(dailyTotal)
+                    .status(status)
+                    .appTimes(appTimes)
+                    .build());
         }
 
         int totalMinutes = totalInsta + totalYoutube + totalKakaotalk + totalChrome;


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 스크린타임 조회 시 유저의 목표 스크린타임 값에 비례한 현재 스크린타임 값이 이하/초과/null 인지 계산하여 상태 값을 넘겨주도록 수정하였습니다.
- 스크린타임 주간 조회 시 날짜뿐만 아니라 요일 값 또한 포함하여 넘겨주도록 수정하였습니다.

## 리뷰 요구사항(Optional)
