### PR TITLE
add: 스크린타임 자동 시간 측정 기능 추가

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/Dnd13th3BackendApplication.java
+++ b/src/main/java/org/minu/dnd13th3backend/Dnd13th3BackendApplication.java
@@ -2,10 +2,12 @@ package org.minu.dnd13th3backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class Dnd13th3BackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/minu/dnd13th3backend/screentime/entity/ScreenTime.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/entity/ScreenTime.java
@@ -5,13 +5,18 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.minu.dnd13th3backend.user.entity.User;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class ScreenTime {
 
     @Id
@@ -28,6 +33,12 @@ public class ScreenTime {
     private int youtubeMinutes;
     private int kakaotalkMinutes;
     private int chromeMinutes;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
 
     @Builder
     public ScreenTime(User user, LocalDate date, int instagramMinutes, int youtubeMinutes, int kakaotalkMinutes, int chromeMinutes) {

--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -13,8 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -31,41 +32,30 @@ public class ScreenTimeService {
         LocalDate today = LocalDate.now();
         Optional<ScreenTime> optionalScreenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), today);
 
-        int prevInsta = optionalScreenTime.map(ScreenTime::getInstagramMinutes).orElse(0);
-        int prevYoutube = optionalScreenTime.map(ScreenTime::getYoutubeMinutes).orElse(0);
-        int prevKakaotalk = optionalScreenTime.map(ScreenTime::getKakaotalkMinutes).orElse(0);
-        int prevChrome = optionalScreenTime.map(ScreenTime::getChromeMinutes).orElse(0);
-        int currentTotalMinutes = prevInsta + prevYoutube + prevKakaotalk + prevChrome;
-
-        Profile profile = profileRepository.findByUserId(user.getId())
-                .orElseThrow(() -> new IllegalStateException("해당 사용자의 프로필을 찾을 수 없습니다: " + user.getId()));
-        int goalMinutes = getGoalMinutes(profile);
-        int maxMinutesForNow = calculateCurrentMaxMinutes(goalMinutes);
-
-        int remainingBudget = maxMinutesForNow - currentTotalMinutes;
-
         ScreenTime screenTime;
+
         if (optionalScreenTime.isPresent()) {
             screenTime = optionalScreenTime.get();
-            if (remainingBudget > 0) {
-                int totalIncrease = random.nextInt(Math.min(remainingBudget, 30)) + 1;
 
-                int[] increases = distributeTotalTime(totalIncrease, 4);
+            LocalDateTime lastUpdate = screenTime.getUpdatedAt() != null ? screenTime.getUpdatedAt() : screenTime.getCreatedAt();
+            if (lastUpdate == null) {
+                lastUpdate = LocalDateTime.now().minusMinutes(5);
+            }
 
+            long minutesPassed = Duration.between(lastUpdate, LocalDateTime.now()).toMinutes();
+
+            if (minutesPassed > 0) {
                 screenTime.updateScreenTime(
-                        prevInsta + increases[0],
-                        prevYoutube + increases[1],
-                        prevKakaotalk + increases[2],
-                        prevChrome + increases[3]
+                        screenTime.getInstagramMinutes() + (int) minutesPassed,
+                        screenTime.getYoutubeMinutes() + (int) minutesPassed,
+                        screenTime.getKakaotalkMinutes() + (int) minutesPassed,
+                        screenTime.getChromeMinutes() + (int) minutesPassed
                 );
             }
         } else {
-            int initialTotalMinutes = 0;
-            if (maxMinutesForNow > 0) {
-                initialTotalMinutes = random.nextInt(Math.min(maxMinutesForNow, 30)) + 1;
-            }
-
+            int initialTotalMinutes = random.nextInt(10) + 1;
             int[] appMinutes = distributeTotalTime(initialTotalMinutes, 4);
+
             screenTime = ScreenTime.builder()
                     .user(user)
                     .date(today)
@@ -109,12 +99,6 @@ public class ScreenTimeService {
         return profile.getScreenTimeGoalType().getMinutes();
     }
 
-    private int calculateCurrentMaxMinutes(int goalMinutes) {
-        double dayProgressRatio = (double) LocalTime.now().toSecondOfDay() / (24.0 * 3600.0);
-        int maxMinutes = (int) (goalMinutes * dayProgressRatio);
-        return Math.min(maxMinutes, goalMinutes);
-    }
-
     @Transactional(readOnly = true)
     public Object getScreenTime(String period, LocalDate date, User user) {
         if ("day".equalsIgnoreCase(period)) {
@@ -130,8 +114,13 @@ public class ScreenTimeService {
         LocalDate targetDate = (date == null) ? LocalDate.now() : date;
         ScreenTime screenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), targetDate).orElse(null);
 
-        Profile profile = profileRepository.findByUserId(user.getId())
-                .orElseThrow(() -> new IllegalStateException("해당 사용자의 프로필을 찾을 수 없습니다: " + user.getId()));
+        Optional<Profile> optionalProfile = profileRepository.findByUserId(user.getId());
+
+        if (optionalProfile.isEmpty()) {
+            return ScreenTimeGetDailyResponse.from(screenTime, "NO_DATA");
+        }
+
+        Profile profile = optionalProfile.get();
         int goalMinutes = getGoalMinutes(profile);
 
         String status = "NO_DATA";
@@ -148,9 +137,9 @@ public class ScreenTimeService {
         LocalDate startOfWeek = today.with(DayOfWeek.MONDAY);
         LocalDate endOfWeek = today.with(DayOfWeek.SUNDAY);
 
-        Profile profile = profileRepository.findByUserId(user.getId())
-                .orElseThrow(() -> new IllegalStateException("해당 사용자의 프로필을 찾을 수 없습니다: " + user.getId()));
-        int goalMinutes = getGoalMinutes(profile);
+        Optional<Profile> optionalProfile = profileRepository.findByUserId(user.getId());
+
+        int goalMinutes = optionalProfile.map(this::getGoalMinutes).orElse(0);
 
         List<ScreenTime> recordedTimes = screenTimeRepository.findByUser_IdAndDateBetween(user.getId(), startOfWeek, endOfWeek);
         Map<LocalDate, ScreenTime> recordedMap = recordedTimes.stream().collect(Collectors.toMap(ScreenTime::getDate, st -> st));
@@ -167,7 +156,9 @@ public class ScreenTimeService {
 
             if (st != null) {
                 dailyTotal = st.getInstagramMinutes() + st.getYoutubeMinutes() + st.getKakaotalkMinutes() + st.getChromeMinutes();
-                status = (dailyTotal > goalMinutes) ? "OVER" : "UNDER";
+                if (optionalProfile.isPresent()) {
+                    status = (dailyTotal > goalMinutes) ? "OVER" : "UNDER";
+                }
                 totalInsta += st.getInstagramMinutes();
                 totalYoutube += st.getYoutubeMinutes();
                 totalKakaotalk += st.getKakaotalkMinutes();


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 스크린타임 생성/갱신 api 호출 시 이전에 호출된 시간과의 간격을 계산하여 그 간격만큼의 시간을 더하여 갱신하도록 계산 로직을 수정했습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic created/updated timestamps for screen time records.
  - Screen time now accumulates automatically between updates for more accurate tracking.

- Improvements
  - Daily and weekly summaries handle absent profiles gracefully, showing “No Data” when applicable.
  - Goal-based status calculation refined for daily and weekly views.

- Bug Fixes
  - Resolved errors when profiles were missing by safely defaulting and preserving summaries.

- Chores
  - Enabled application-wide auditing to support timestamping and future reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->