### PR TITLE
fix: 최초 스크린타임 생성 값 수정

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -12,10 +12,7 @@ import org.minu.dnd13th3backend.user.type.ScreenTimeGoalType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.DayOfWeek;
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -53,7 +50,17 @@ public class ScreenTimeService {
                 );
             }
         } else {
-            int initialTotalMinutes = random.nextInt(10) + 1;
+            Profile profile = profileRepository.findByUserId(user.getId())
+                    .orElseThrow(() -> new IllegalStateException("해당 사용자의 프로필을 찾을 수 없습니다: " + user.getId()));
+
+            int goalMinutes = getGoalMinutes(profile);
+            int maxMinutesForNow = calculateCurrentMaxMinutes(goalMinutes);
+
+            int initialTotalMinutes = 0;
+            if (maxMinutesForNow > 0) {
+                initialTotalMinutes = random.nextInt(maxMinutesForNow) + 1;
+            }
+
             int[] appMinutes = distributeTotalTime(initialTotalMinutes, 4);
 
             screenTime = ScreenTime.builder()
@@ -67,6 +74,7 @@ public class ScreenTimeService {
         }
         return screenTimeRepository.save(screenTime);
     }
+
 
     private int[] distributeTotalTime(int total, int parts) {
         int[] result = new int[parts];
@@ -108,6 +116,12 @@ public class ScreenTimeService {
         } else {
             throw new IllegalArgumentException("Invalid period value. It must be 'day' or 'week'.");
         }
+    }
+
+    private int calculateCurrentMaxMinutes(int goalMinutes) {
+        double dayProgressRatio = (double) LocalTime.now().toSecondOfDay() / (24.0 * 3600.0);
+        int maxMinutes = (int) (goalMinutes * dayProgressRatio);
+        return Math.min(maxMinutes, goalMinutes);
     }
 
     private ScreenTimeGetDailyResponse getDailyScreenTime(LocalDate date, User user) {


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 최초 스크린타임 생성 시 임의의 값이 아닌 사용자의 프로필 속 목표 스크린타임 값과 현재 시간을 비례 측정하여 임의의 초기값을 생성하도록 수정하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Screen time is now dynamically generated based on the current time of day and your daily goal, producing more realistic per-app distributions.

* **Bug Fixes**
  * Generated screen time no longer exceeds your daily goal.
  * Initial daily totals start at sensible values instead of arbitrary amounts, improving consistency throughout the day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->