### PR TITLE
feat: 진행중/완료한 챌린지 조회 api 분기

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/controller/ChallengeController.java
@@ -8,12 +8,9 @@ import org.minu.dnd13th3backend.challenge.entity.Challenge;
 import org.minu.dnd13th3backend.challenge.service.ChallengeService;
 import org.minu.dnd13th3backend.common.dto.ResponseDto;
 import org.minu.dnd13th3backend.user.entity.User;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/challenge")
@@ -28,28 +25,32 @@ public class ChallengeController {
             @AuthenticationPrincipal User user
     ) {
         Challenge challenge = challengeService.createChallenge(request, user);
-
         ChallengeCreateResponse responseData = new ChallengeCreateResponse(challenge.getId());
-
         return ResponseEntity.ok(ResponseDto.success("챌린지가 성공적으로 생성되었습니다.", responseData));
     }
 
     @GetMapping
     public ResponseEntity<ResponseDto<ChallengeListResponse>> getChallenges(
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @AuthenticationPrincipal User user
     ) {
-        ChallengeListResponse responseData = challengeService.getChallenges(startDate, endDate, user);
+        ChallengeListResponse responseData = challengeService.getChallenges(user);
 
         if (responseData.getChallenges().isEmpty()) {
-            String message = (startDate != null && endDate != null) ?
-                    "해당 기간에 완료된 챌린지가 없습니다." :
-                    "참여 중인 챌린지가 없습니다.";
-            return ResponseEntity.ok(ResponseDto.success(message, responseData));
+            return ResponseEntity.ok(ResponseDto.success("참여 중인 챌린지가 없습니다.", responseData));
         }
 
         return ResponseEntity.ok(ResponseDto.success("챌린지 조회가 성공했습니다.", responseData));
+    }
+
+    @GetMapping("/history")
+    public ResponseEntity<ResponseDto<ChallengeListResponse>> getChallengeHistory(
+            @AuthenticationPrincipal User user
+    ) {
+        ChallengeListResponse responseData = challengeService.getChallengeHistory(user);
+        if (responseData.getChallenges().isEmpty()) {
+            return ResponseEntity.ok(ResponseDto.success("완료된 챌린지가 없습니다.", responseData));
+        }
+        return ResponseEntity.ok(ResponseDto.success("완료된 챌린지 조회가 성공했습니다.", responseData));
     }
 
     @PostMapping("/inviteUrl/{challengeId}")

--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
@@ -17,9 +17,7 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
             User user, LocalDate today1, LocalDate today2
     );
 
-    List<ChallengeParticipant> findByUserAndChallenge_StartDateAndChallenge_EndDateOrderByChallenge_CreatedAtDesc(
-            User user, LocalDate startDate, LocalDate endDate
-    );
+    List<ChallengeParticipant> findByUserAndChallenge_EndDateBeforeOrderByChallenge_StartDateDesc(User user, LocalDate today);
 
     List<ChallengeParticipant> findByChallenge_Id(Long challengeId);
 

--- a/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
@@ -62,81 +62,94 @@ public class ChallengeService {
     }
 
     @Transactional(readOnly = true)
-    public ChallengeListResponse getChallenges(LocalDate startDate, LocalDate endDate, User user) {
-
-        List<ChallengeParticipant> userParticipations;
-        if (startDate != null && endDate != null) {
-            userParticipations = participantRepository.findByUserAndChallenge_StartDateAndChallenge_EndDateOrderByChallenge_CreatedAtDesc(user, startDate, endDate);
-        } else {
-            LocalDate today = LocalDate.now();
-            userParticipations = participantRepository.findByUserAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqualOrderByChallenge_CreatedAtDesc(user, today, today);
-        }
+    public ChallengeListResponse getChallenges(User user) {
+        LocalDate today = LocalDate.now();
+        List<ChallengeParticipant> userParticipations = participantRepository.findByUserAndChallenge_StartDateLessThanEqualAndChallenge_EndDateGreaterThanEqualOrderByChallenge_CreatedAtDesc(user, today, today);
 
         if (userParticipations.isEmpty()) {
             return ChallengeListResponse.builder().challenges(List.of()).build();
         }
 
         List<ChallengeGetResponse> challengeResponses = userParticipations.stream()
-                .map(participation -> {
-                    Challenge challenge = participation.getChallenge();
-                    List<ChallengeParticipant> allParticipants = participantRepository.findByChallenge_Id(challenge.getId());
-
-                    List<ChallengeGetResponse.ParticipantRecord> participantRecords = allParticipants.stream()
-                            .map(participant -> {
-                                User participantUser = participant.getUser();
-                                List<ScreenTime> screenTimes = screenTimeRepository.findByUser_IdAndDateBetween(
-                                        participantUser.getId(), challenge.getStartDate(), challenge.getEndDate()
-                                );
-
-                                long totalInsta = screenTimes.stream().mapToLong(ScreenTime::getInstagramMinutes).sum();
-                                long totalYoutube = screenTimes.stream().mapToLong(ScreenTime::getYoutubeMinutes).sum();
-                                long totalKakaotalk = screenTimes.stream().mapToLong(ScreenTime::getKakaotalkMinutes).sum();
-                                long totalChrome = screenTimes.stream().mapToLong(ScreenTime::getChromeMinutes).sum();
-                                long currentTimeMinutes = totalInsta + totalYoutube + totalKakaotalk + totalChrome;
-
-                                double achievementRate;
-                                if (challenge.getGoalTimeMinutes() > 0) {
-                                    double usageRate = ((double) currentTimeMinutes / challenge.getGoalTimeMinutes()) * 100.0;
-                                    achievementRate = Math.max(0, 100.0 - usageRate);
-                                } else {
-                                    achievementRate = (currentTimeMinutes == 0) ? 100.0 : 0.0;
-                                }
-
-                                String status;
-                                if (LocalDate.now().isAfter(challenge.getEndDate())) {
-                                    status = (currentTimeMinutes <= challenge.getGoalTimeMinutes()) ? "달성" : "실패";
-                                } else {
-                                    status = "진행 중";
-                                }
-
-                                return ChallengeGetResponse.ParticipantRecord.builder()
-                                        .userId(participantUser.getId())
-                                        .nickname(participantUser.getProfile().getNickname())
-                                        .characterIndex(participantUser.getProfile().getCharacterIndex())
-                                        .currentTimeMinutes(currentTimeMinutes)
-                                        .instagramMinutes(totalInsta)
-                                        .youtubeMinutes(totalYoutube)
-                                        .kakaotalkMinutes(totalKakaotalk)
-                                        .chromeMinutes(totalChrome)
-                                        .achievementRate(achievementRate)
-                                        .status(status)
-                                        .build();
-                            })
-                            .collect(Collectors.toList());
-
-                    return ChallengeGetResponse.builder()
-                            .challengeId(challenge.getId())
-                            .startDate(challenge.getStartDate())
-                            .endDate(challenge.getEndDate())
-                            .title(challenge.getTitle())
-                            .goalTimeMinutes(challenge.getGoalTimeMinutes())
-                            .participants(participantRecords)
-                            .build();
-                })
+                .map(this::mapParticipationToChallengeGetResponse)
                 .collect(Collectors.toList());
 
         return ChallengeListResponse.builder().challenges(challengeResponses).build();
     }
+
+    @Transactional(readOnly = true)
+    public ChallengeListResponse getChallengeHistory(User user) {
+        LocalDate today = LocalDate.now();
+        List<ChallengeParticipant> userParticipations = participantRepository.findByUserAndChallenge_EndDateBeforeOrderByChallenge_StartDateDesc(user, today);
+
+        if (userParticipations.isEmpty()) {
+            return ChallengeListResponse.builder().challenges(List.of()).build();
+        }
+
+        List<ChallengeGetResponse> challengeResponses = userParticipations.stream()
+                .map(this::mapParticipationToChallengeGetResponse)
+                .collect(Collectors.toList());
+
+        return ChallengeListResponse.builder().challenges(challengeResponses).build();
+    }
+
+    private ChallengeGetResponse mapParticipationToChallengeGetResponse(ChallengeParticipant participation) {
+        Challenge challenge = participation.getChallenge();
+        List<ChallengeParticipant> allParticipants = participantRepository.findByChallenge_Id(challenge.getId());
+
+        List<ChallengeGetResponse.ParticipantRecord> participantRecords = allParticipants.stream()
+                .map(participant -> {
+                    User participantUser = participant.getUser();
+                    List<ScreenTime> screenTimes = screenTimeRepository.findByUser_IdAndDateBetween(
+                            participantUser.getId(), challenge.getStartDate(), challenge.getEndDate()
+                    );
+
+                    long totalInsta = screenTimes.stream().mapToLong(ScreenTime::getInstagramMinutes).sum();
+                    long totalYoutube = screenTimes.stream().mapToLong(ScreenTime::getYoutubeMinutes).sum();
+                    long totalKakaotalk = screenTimes.stream().mapToLong(ScreenTime::getKakaotalkMinutes).sum();
+                    long totalChrome = screenTimes.stream().mapToLong(ScreenTime::getChromeMinutes).sum();
+                    long currentTimeMinutes = totalInsta + totalYoutube + totalKakaotalk + totalChrome;
+
+                    double achievementRate;
+                    if (challenge.getGoalTimeMinutes() > 0) {
+                        double usageRate = ((double) currentTimeMinutes / challenge.getGoalTimeMinutes()) * 100.0;
+                        achievementRate = Math.max(0, 100.0 - usageRate);
+                    } else {
+                        achievementRate = (currentTimeMinutes == 0) ? 100.0 : 0.0;
+                    }
+
+                    String status;
+                    if (LocalDate.now().isAfter(challenge.getEndDate())) {
+                        status = (currentTimeMinutes <= challenge.getGoalTimeMinutes()) ? "달성" : "실패";
+                    } else {
+                        status = "진행 중";
+                    }
+
+                    return ChallengeGetResponse.ParticipantRecord.builder()
+                            .userId(participantUser.getId())
+                            .nickname(participantUser.getProfile().getNickname())
+                            .characterIndex(participantUser.getProfile().getCharacterIndex())
+                            .currentTimeMinutes(currentTimeMinutes)
+                            .instagramMinutes(totalInsta)
+                            .youtubeMinutes(totalYoutube)
+                            .kakaotalkMinutes(totalKakaotalk)
+                            .chromeMinutes(totalChrome)
+                            .achievementRate(achievementRate)
+                            .status(status)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return ChallengeGetResponse.builder()
+                .challengeId(challenge.getId())
+                .startDate(challenge.getStartDate())
+                .endDate(challenge.getEndDate())
+                .title(challenge.getTitle())
+                .goalTimeMinutes(challenge.getGoalTimeMinutes())
+                .participants(participantRecords)
+                .build();
+    }
+
 
     @Transactional
     public String generateInviteLink(Long challengeId, User user) {


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 기존의 완료한 챌린지를 start_date, end_date 값을 전달받아 조회하는 api를 제거하고, 전달 값 없이 사용자의 완료한 챌린지를 모두 조회할 수 있는 api를 구현하였습니다.
- 기존의 진행 중/완료한 챌린지를 조회하는 하나의 api를 각각 다른 api로 구분하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new endpoint to view your completed challenge history, sorted with the most recent first.
  - The current challenges view now automatically shows only ongoing challenges based on today—no date filters needed.
  - Unified empty-state messages:
    - When no active challenges: “참여 중인 챌린지가 없습니다.”
    - When no completed challenges: “완료된 챌린지가 없습니다.”
  - Success message for completed challenges retrieval: “완료된 챌린지 조회가 성공했습니다.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->