### PR TITLE
add: 챌린지 조회 시 프로필이 등록되지 않은 참가자에 대한 에러 핸들링 추가

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/repository/ChallengeParticipantRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Repository
 public interface ChallengeParticipantRepository extends JpaRepository<ChallengeParticipant, Long> {
 
-    @Query("SELECT cp FROM ChallengeParticipant cp JOIN FETCH cp.user u JOIN FETCH u.profile " +
+    @Query("SELECT cp FROM ChallengeParticipant cp JOIN FETCH cp.user u LEFT JOIN FETCH u.profile " +
             "WHERE cp.user = :user " +
             "AND cp.challenge.startDate <= :today1 " +
             "AND cp.challenge.endDate >= :today2 " +
@@ -23,13 +23,13 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
             @Param("user") User user, @Param("today1") LocalDate today1, @Param("today2") LocalDate today2
     );
 
-    @Query("SELECT cp FROM ChallengeParticipant cp JOIN FETCH cp.user u JOIN FETCH u.profile " +
+    @Query("SELECT cp FROM ChallengeParticipant cp JOIN FETCH cp.user u LEFT JOIN FETCH u.profile " +
             "WHERE cp.user = :user " +
             "AND cp.challenge.endDate < :today " +
             "ORDER BY cp.challenge.startDate DESC")
     List<ChallengeParticipant> findByUserAndChallenge_EndDateBeforeOrderByChallenge_StartDateDesc(@Param("user") User user, @Param("today") LocalDate today);
 
-    @Query("SELECT cp FROM ChallengeParticipant cp JOIN FETCH cp.user u JOIN FETCH u.profile WHERE cp.challenge.id = :challengeId")
+    @Query("SELECT cp FROM ChallengeParticipant cp JOIN FETCH cp.user u LEFT JOIN FETCH u.profile WHERE cp.challenge.id = :challengeId")
     List<ChallengeParticipant> findByChallenge_Id(@Param("challengeId") Long challengeId);
 
     boolean existsByChallengeAndUser(Challenge challenge, User user);

--- a/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
@@ -100,6 +100,11 @@ public class ChallengeService {
         List<ChallengeGetResponse.ParticipantRecord> participantRecords = allParticipants.stream()
                 .map(participant -> {
                     User participantUser = participant.getUser();
+
+                    if (participantUser.getProfile() == null) {
+                        throw new BusinessException(ErrorCode.PARTICIPANT_PROFILE_NOT_FOUND);
+                    }
+
                     List<ScreenTime> screenTimes = screenTimeRepository.findByUser_IdAndDateBetween(
                             participantUser.getId(), challenge.getStartDate(), challenge.getEndDate()
                     );
@@ -150,7 +155,6 @@ public class ChallengeService {
                 .build();
     }
 
-
     @Transactional
     public String generateInviteLink(Long challengeId, User user) {
         Challenge challenge = challengeRepository.findById(challengeId)
@@ -180,6 +184,10 @@ public class ChallengeService {
 
         if (LocalDate.now().isAfter(inviteCode.getExpiresAt())) {
             throw new BusinessException(ErrorCode.INVITE_CODE_EXPIRED);
+        }
+
+        if (user.getProfile() == null) {
+            throw new BusinessException(ErrorCode.PROFILE_NOT_FOUND);
         }
 
         Challenge challenge = inviteCode.getChallenge();

--- a/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     CHALLENGE_FULL(HttpStatus.BAD_REQUEST, "챌린지 인원이 가득 찼습니다."),
     CANNOT_JOIN_OWN_CHALLENGE(HttpStatus.BAD_REQUEST, "본인이 생성한 챌린지에는 참여할 수 없습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "해당 작업에 대한 권한이 없습니다."),
+    PARTICIPANT_PROFILE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "참가자 중 프로필이 등록되지 않은 사용자가 있습니다."),
 
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 하나의 챌린지에 대해 여러 명의 참가자가 참여했을 때, 프로필이 없는 참가자가 있는 경우 에러를 나타내는 핸들링을 추가했습니다. 

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when viewing challenges with participants who haven’t set up a profile.
  * Added validation to stop joining a challenge without a user profile, with a clear error message.
  * Improved reliability when loading challenge participants to reduce unexpected failures.
  * Ensured consistent behavior and ordering when retrieving a user’s past and ongoing challenges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->