### PR TITLE
fix: 프로필 수정 목표 타입 enum 매핑되게 수정

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
@@ -30,11 +30,15 @@ public class ProfileUpdateRequest {
     public static class Goal {
         @NotNull(message = "목표 타입은 필수입니다")
         @Schema(description = "목표 타입", example = "CUSTOM")
-        private GoalType type;
+        private String type;
 
         @Size(max = 100, message = "커스텀 목표는 100자 이하여야 합니다")
         @Schema(description = "커스텀 목표 (type이 CUSTOM일 때 필수)", example = "디지털 디톡스 챌린지 성공하기", maxLength = 100)
         private String custom;
+
+        public GoalType getGoalType() {
+            return GoalType.fromString(type);
+        }
     }
 
     @Getter
@@ -51,7 +55,7 @@ public class ProfileUpdateRequest {
     }
 
     public GoalType getGoalType() {
-        return goal.getType();
+        return goal.getGoalType();
     }
 
     public String getGoalCustom() {


### PR DESCRIPTION
## 작업 내용
- 프로필 수정API에서 수정할려는 목표값 받아서 enum으로 매핑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile Update API now accepts the goal type as a string in the request body. Inputs are converted internally to ensure consistent handling, improving compatibility with diverse clients and payload formats.
  * Validation remains enforced on the goal type field, preserving existing safeguards while centralizing type conversion for more reliable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->