### PR TITLE
fix: 한국 시간 기준 스크린타임 생성 api 수정

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -23,23 +23,25 @@ public class ScreenTimeService {
     private final ScreenTimeRepository screenTimeRepository;
     private final ProfileRepository profileRepository;
     private final Random random = new Random();
+    private final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     @Transactional
     public ScreenTime generateAndSaveScreenTime(User user) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(KST);
         Optional<ScreenTime> optionalScreenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), today);
 
         ScreenTime screenTime;
 
         if (optionalScreenTime.isPresent()) {
             screenTime = optionalScreenTime.get();
+            LocalDateTime now = LocalDateTime.now(KST);
 
             LocalDateTime lastUpdate = screenTime.getUpdatedAt() != null ? screenTime.getUpdatedAt() : screenTime.getCreatedAt();
             if (lastUpdate == null) {
-                lastUpdate = LocalDateTime.now().minusMinutes(5);
+                lastUpdate = now.minusMinutes(5);
             }
 
-            long minutesPassed = Duration.between(lastUpdate, LocalDateTime.now()).toMinutes();
+            long minutesPassed = Duration.between(lastUpdate, now).toMinutes();
 
             if (minutesPassed > 0) {
                 screenTime.updateScreenTime(
@@ -58,7 +60,12 @@ public class ScreenTimeService {
 
             int initialTotalMinutes = 0;
             if (maxMinutesForNow > 0) {
-                initialTotalMinutes = random.nextInt(maxMinutesForNow) + 1;
+                if (maxMinutesForNow > 1) {
+                    int minMinutes = maxMinutesForNow / 2;
+                    initialTotalMinutes = random.nextInt(maxMinutesForNow - minMinutes + 1) + minMinutes;
+                } else {
+                    initialTotalMinutes = maxMinutesForNow;
+                }
             }
 
             int[] appMinutes = distributeTotalTime(initialTotalMinutes, 4);
@@ -119,13 +126,14 @@ public class ScreenTimeService {
     }
 
     private int calculateCurrentMaxMinutes(int goalMinutes) {
-        double dayProgressRatio = (double) LocalTime.now().toSecondOfDay() / (24.0 * 3600.0);
+        LocalTime now = LocalTime.now(KST);
+        double dayProgressRatio = (double) now.toSecondOfDay() / (24.0 * 3600.0);
         int maxMinutes = (int) (goalMinutes * dayProgressRatio);
         return Math.min(maxMinutes, goalMinutes);
     }
 
     private ScreenTimeGetDailyResponse getDailyScreenTime(LocalDate date, User user) {
-        LocalDate targetDate = (date == null) ? LocalDate.now() : date;
+        LocalDate targetDate = (date == null) ? LocalDate.now(KST) : date;
         ScreenTime screenTime = screenTimeRepository.findByUser_IdAndDate(user.getId(), targetDate).orElse(null);
 
         Optional<Profile> optionalProfile = profileRepository.findByUserId(user.getId());
@@ -147,7 +155,7 @@ public class ScreenTimeService {
     }
 
     private ScreenTimeGetWeeklyResponse getWeeklyScreenTime(LocalDate date, User user) {
-        LocalDate today = (date == null) ? LocalDate.now() : date;
+        LocalDate today = (date == null) ? LocalDate.now(KST) : date;
         LocalDate startOfWeek = today.with(DayOfWeek.MONDAY);
         LocalDate endOfWeek = today.with(DayOfWeek.SUNDAY);
 


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 사용자의 목표 스크린타임과 현재 시간을 기준으로 스크린타임 값을 생성하는 api 로직에서, 한국 시간을 기준으로 서버에서 동작하도록 api를 일부 수정하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More realistic initial daily screen time when starting without prior data, adjusting to time of day.
- Bug Fixes
  - All screen time calculations now consistently use Asia/Seoul time, correcting day/week summaries and progress.
  - Improved “last updated” handling to prevent unexpected jumps or drift in elapsed minutes.
  - Default dates for daily and weekly views now correctly align with the user’s local (KST) day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->