### PR TITLE
fix: KST 시간 기반 스크린타임 생성/갱신

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -34,14 +34,16 @@ public class ScreenTimeService {
 
         if (optionalScreenTime.isPresent()) {
             screenTime = optionalScreenTime.get();
-            LocalDateTime now = LocalDateTime.now(KST);
 
-            LocalDateTime lastUpdate = screenTime.getUpdatedAt() != null ? screenTime.getUpdatedAt() : screenTime.getCreatedAt();
-            if (lastUpdate == null) {
-                lastUpdate = now.minusMinutes(5);
+            LocalDateTime nowInKst = LocalDateTime.now(KST);
+
+            LocalDateTime lastUpdateFromDb = screenTime.getUpdatedAt() != null ? screenTime.getUpdatedAt() : screenTime.getCreatedAt();
+
+            if (lastUpdateFromDb == null) {
+                lastUpdateFromDb = nowInKst.minusMinutes(5);
             }
 
-            long minutesPassed = Duration.between(lastUpdate, now).toMinutes();
+            long minutesPassed = Duration.between(lastUpdateFromDb, nowInKst).toMinutes();
 
             if (minutesPassed > 0) {
                 screenTime.updateScreenTime(


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- KST 시간을 기준으로 DB의 시간 값과 현재 시간을 계산하여 스크린타임 값을 생성/갱신 하도록 api를 수정하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined screen time update logic for improved readability and maintainability, with no change to user-facing behavior.
  * Standardized time handling and default fallbacks to ensure consistent minute calculations.
  * No impact on existing data or features; performance and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->