### PR TITLE
fix: mysql 서버 시간 형식 KST 통일화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,11 @@ jobs:
                   - ./.env
                 volumes:
                   - db_data:/var/lib/mysql
+                command:
+                  - --default-authentication-plugin=mysql_native_password
+                  - --character-set-server=utf8mb4
+                  - --collation-server=utf8mb4_unicode_ci
+                  - --time-zone=Asia/Seoul
                 healthcheck:
                   test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
                   interval: 10s


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- mysql 서버에서의 시간 형식이 UTC로 설정되어있어 KST 형식의 코드 로직와 일치하지 않아 생기는 오류를 해결하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated deployment workflow to configure the database service with explicit MySQL startup options: native password authentication, utf8mb4 character set, utf8mb4_unicode_ci collation, and Asia/Seoul time zone.
  - Applies these settings via the command in the generated docker-compose during “Deploy to EC2.”
  - No changes to health checks, volumes, or networking; only startup behavior is adjusted.
  - Results in consistent encoding and time zone behavior across deployed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->