### PR TITLE
fix: deploy.yml mysql 시간 설정 방식 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,13 +78,10 @@ jobs:
                   - "3306:3306"
                 env_file:
                   - ./.env
+                environment:
+                  - TZ=Asia/Seoul
                 volumes:
                   - db_data:/var/lib/mysql
-                command:
-                  - --default-authentication-plugin=mysql_native_password
-                  - --character-set-server=utf8mb4
-                  - --collation-server=utf8mb4_unicode_ci
-                  - --time-zone=Asia/Seoul
                 healthcheck:
                   test: ["CMD-SHELL", "mysqladmin ping -h localhost -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
                   interval: 10s


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- deploy.yml mysql 시간 설정 방식 수정

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to set the database timezone via environment variable (Asia/Seoul) instead of command-line flags, improving operational consistency.
  * Ensures more consistent timestamps across data, schedules, and logs for users in the Asia/Seoul region.
  * No changes to application features or behavior; health checks and other deployment settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->