### PR TITLE
fix: screentime 시간 타입 변환

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/screentime/entity/ScreenTime.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/entity/ScreenTime.java
@@ -8,15 +8,13 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.minu.dnd13th3backend.user.entity.User;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 public class ScreenTime {
 
     @Id
@@ -35,10 +33,12 @@ public class ScreenTime {
     private int chromeMinutes;
 
     @CreationTimestamp
-    private LocalDateTime createdAt;
+    @Column(columnDefinition = "TIMESTAMP")
+    private Instant createdAt;
 
     @UpdateTimestamp
-    private LocalDateTime updatedAt;
+    @Column(columnDefinition = "TIMESTAMP")
+    private Instant updatedAt;
 
     @Builder
     public ScreenTime(User user, LocalDate date, int instagramMinutes, int youtubeMinutes, int kakaotalkMinutes, int chromeMinutes) {

--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -35,15 +35,14 @@ public class ScreenTimeService {
         if (optionalScreenTime.isPresent()) {
             screenTime = optionalScreenTime.get();
 
-            LocalDateTime nowInKst = LocalDateTime.now(KST);
+            Instant now = Instant.now();
+            Instant lastUpdate = screenTime.getUpdatedAt() != null ? screenTime.getUpdatedAt() : screenTime.getCreatedAt();
 
-            LocalDateTime lastUpdateFromDb = screenTime.getUpdatedAt() != null ? screenTime.getUpdatedAt() : screenTime.getCreatedAt();
-
-            if (lastUpdateFromDb == null) {
-                lastUpdateFromDb = nowInKst.minusMinutes(5);
+            if (lastUpdate == null) {
+                lastUpdate = now.minus(Duration.ofMinutes(5));
             }
 
-            long minutesPassed = Duration.between(lastUpdateFromDb, nowInKst).toMinutes();
+            long minutesPassed = Duration.between(lastUpdate, now).toMinutes();
 
             if (minutesPassed > 0) {
                 screenTime.updateScreenTime(


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- screentime 테이블의 시간 타입을 datetime 에서 instant & timestamp로 변환하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screen time minutes now update more consistently after inactivity gaps.
  * Improved reliability of timestamp-based updates, reducing missed or delayed increments.
  * More consistent timestamp ordering and display across time zones.

* **Refactor**
  * Standardized time handling to use absolute, zone-agnostic timestamps for greater consistency across regions and environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->