### PR TITLE
add: 챌린지 조회 시 해당 챌린지의 초대 링크 값 포함

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeGetResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/ChallengeGetResponse.java
@@ -24,9 +24,11 @@ public class ChallengeGetResponse {
     @JsonProperty("goal_time_minutes")
     private int goalTimeMinutes;
 
+    @JsonProperty("invite_url")
+    private String inviteUrl;
+
     private List<ParticipantRecord> participants;
 
-    // 참가자 한 명의 정보를 담는 내부 클래스
     @Getter
     @Builder
     public static class ParticipantRecord {

--- a/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/service/ChallengeService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -97,6 +98,12 @@ public class ChallengeService {
         Challenge challenge = participation.getChallenge();
         List<ChallengeParticipant> allParticipants = participantRepository.findByChallenge_Id(challenge.getId());
 
+        Optional<InviteCode> optionalInviteCode = inviteCodeRepository.findByChallenge(challenge);
+
+        String inviteUrl = optionalInviteCode
+                .map(inviteCode -> frontendBaseUrl + "/join?code=" + inviteCode.getCode())
+                .orElse(null);
+
         List<ChallengeGetResponse.ParticipantRecord> participantRecords = allParticipants.stream()
                 .map(participant -> {
                     User participantUser = participant.getUser();
@@ -151,6 +158,7 @@ public class ChallengeService {
                 .endDate(challenge.getEndDate())
                 .title(challenge.getTitle())
                 .goalTimeMinutes(challenge.getGoalTimeMinutes())
+                .inviteUrl(inviteUrl)
                 .participants(participantRecords)
                 .build();
     }


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 챌린지 조회 시 해당 챌린지의 초대 링크(invite_url) 값을 res에 포함하여 전달하도록 수정하였습니다.
- 해당 링크를 생성한 사용자가 아닌, 단순히 챌린지에 참가한 사용자가 챌린지 조회 api를 호출하여도 초대 링크 값을 반환할 수 있습니다.
- 만약 초대 링크를 생성하지 않은 챌린지를 조회한다면 invite_url 값은 null로 반환됩니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Challenge details now include a shareable invite link when available, enabling quick joining via a single URL.
  - The invite link appears in challenge retrieval responses and will be absent when no invite is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->