### PR TITLE
feat: 프로필 목표타임에 12시간 추가

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileRequest.java
@@ -48,7 +48,7 @@ public class ProfileRequest {
     @Schema(description = "스크린 타임 목표 정보")
     public static class ScreenTimeGoal {
         @NotNull(message = "스크린 타임 목표 타입은 필수입니다")
-        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "CUSTOM"})
+        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "12HOURS", "CUSTOM"})
         private String type;
 
         @Size(max = 100, message = "커스텀 스크린 타임 목표는 100자 이하여야 합니다")
@@ -71,6 +71,7 @@ public class ProfileRequest {
             case "4HOURS": return ScreenTimeGoalType.FOUR_HOURS;
             case "6HOURS": return ScreenTimeGoalType.SIX_HOURS;
             case "8HOURS": return ScreenTimeGoalType.EIGHT_HOURS;
+            case "12HOURS": return ScreenTimeGoalType.TWELVE_HOURS;
             case "CUSTOM": return ScreenTimeGoalType.CUSTOM;
             default: throw new IllegalArgumentException("Invalid screen time goal type: " + type);
         }

--- a/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
@@ -46,7 +46,7 @@ public class ProfileUpdateRequest {
     @Schema(description = "스크린 타임 목표 정보")
     public static class ScreenTimeGoal {
         @NotNull(message = "스크린 타임 목표 타입은 필수입니다")
-        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "CUSTOM"})
+        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "12HOURS", "CUSTOM"})
         private String type;
 
         @Size(max = 100, message = "커스텀 스크린 타임 목표는 100자 이하여야 합니다")
@@ -69,6 +69,7 @@ public class ProfileUpdateRequest {
             case "4HOURS": return ScreenTimeGoalType.FOUR_HOURS;
             case "6HOURS": return ScreenTimeGoalType.SIX_HOURS;
             case "8HOURS": return ScreenTimeGoalType.EIGHT_HOURS;
+            case "12HOURS": return ScreenTimeGoalType.TWELVE_HOURS;
             case "CUSTOM": return ScreenTimeGoalType.CUSTOM;
             default: throw new IllegalArgumentException("Invalid screen time goal type: " + type);
         }

--- a/src/main/java/org/minu/dnd13th3backend/user/type/ScreenTimeGoalType.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/type/ScreenTimeGoalType.java
@@ -8,6 +8,7 @@ public enum ScreenTimeGoalType {
     FOUR_HOURS("4HOURS", 240),
     SIX_HOURS("6HOURS", 360),
     EIGHT_HOURS("8HOURS", 480),
+    TWELVE_HOURS("12HOURS", 720),
     CUSTOM("CUSTOM", 0);
 
     private final String value;
@@ -42,6 +43,8 @@ public enum ScreenTimeGoalType {
                 return SIX_HOURS;
             case "8HOURS":
                 return EIGHT_HOURS;
+            case "12HOURS":
+                return TWELVE_HOURS;
             case "custom":
                 return CUSTOM;
             default:


### PR DESCRIPTION
## 작업 내용
- 프로필 목표타임 enum값에 12시간 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a 12-hour screen time goal option; users can now choose “12HOURS” (720 minutes) when creating or updating their screen time goal.

- Documentation
  - API docs updated to list “12HOURS” (and its numeric alias 720) as an accepted screen time goal value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->