### PR TITLE
fix: 스크린타임 custom 값 파싱 후 적용

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -106,8 +106,20 @@ public class ScreenTimeService {
 
     private int getGoalMinutes(Profile profile) {
         if (profile.getScreenTimeGoalType() == ScreenTimeGoalType.CUSTOM) {
+            String customGoal = profile.getScreenTimeGoalCustom();
+
+            if (customGoal == null || customGoal.trim().isEmpty()) {
+                return 240;
+            }
+
             try {
-                return Integer.parseInt(profile.getScreenTimeGoalCustom());
+                String numericString = customGoal.replaceAll("[^\\d]", "");
+
+                if (numericString.isEmpty()) {
+                    return 240;
+                }
+
+                return Integer.parseInt(numericString);
             } catch (NumberFormatException e) {
                 return 240;
             }


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 온보딩 프로필 등록 시 목표 스크린타임 값을 custom으로 입력할 때, minutes 등의 단위를 붙이지 않아도 자동으로 분 단위로 인식하여 스크린 타임 생성 시 사용할 수 있도록 로직을 수정했습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom screen time goals.
  * Invalid, blank, or non-numeric inputs now safely default to 240 minutes.
  * More tolerant parsing allows extracting numbers from mixed-character inputs.
  * Non-custom goal behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->