### PR TITLE
add: 챌린지 초대 수락 시 해당 챌린지의 목표 스크린 타임 값 반환

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteJoinResponse.java
+++ b/src/main/java/org/minu/dnd13th3backend/challenge/dto/response/InviteJoinResponse.java
@@ -22,11 +22,15 @@ public class InviteJoinResponse {
 
     private final String title;
 
+    @JsonProperty("goal_time_minutes")
+    private final int goalTimeMinutes;
+
     public InviteJoinResponse(Challenge challenge, String message) {
         this.message = message;
         this.challengeId = challenge.getId();
         this.startDate = challenge.getStartDate();
         this.endDate = challenge.getEndDate();
         this.title = challenge.getTitle();
+        this.goalTimeMinutes = challenge.getGoalTimeMinutes();
     }
 }


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 챌린지 초대 링크 수락 시 해당 챌린지의 목표 스크린 타임 값을 res에 포함하여 반환하도록 수정했습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The challenge invite/join API response now includes a goal_time_minutes field, exposing the challenge’s target duration (in minutes) to clients.
  - This enables apps to display, validate, or sort by challenge time goals directly from the response.
  - The field is returned in JSON as goal_time_minutes for clarity and consistency.
  - Backward compatible: this is an additive change; existing integrations continue to work without modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->