### PR TITLE
fix: 목표타임 12시간 삭제 및 custom 목표타임이 12시간 넘으면 에러처리

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
+++ b/src/main/java/org/minu/dnd13th3backend/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
+    SCREEN_TIME_GOAL_CUSTOM_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "커스텀 스크린 타임 목표는 12시간(720분)을 초과할 수 없습니다."),
     
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileRequest.java
@@ -48,9 +48,7 @@ public class ProfileRequest {
     @Schema(description = "스크린 타임 목표 정보")
     public static class ScreenTimeGoal {
         @NotNull(message = "스크린 타임 목표 타입은 필수입니다")
-
-        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "12HOURS", "120", "240", "360", "480", "720", "CUSTOM"})
-
+        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "120", "240", "360", "480", "CUSTOM"})
         private String type;
 
         @Size(max = 100, message = "커스텀 스크린 타임 목표는 100자 이하여야 합니다")
@@ -67,10 +65,8 @@ public class ProfileRequest {
     }
 
     public ScreenTimeGoalType getScreenTimeGoalType() {
-
         String type = screenTimeGoal.getType();
         switch (type) {
-
             case "2HOURS":
             case "120": return ScreenTimeGoalType.TWO_HOURS;
             case "4HOURS":
@@ -79,9 +75,6 @@ public class ProfileRequest {
             case "360": return ScreenTimeGoalType.SIX_HOURS;
             case "8HOURS":
             case "480": return ScreenTimeGoalType.EIGHT_HOURS;
-            case "12HOURS": 
-            case "720": return ScreenTimeGoalType.TWELVE_HOURS;
-
             case "CUSTOM": return ScreenTimeGoalType.CUSTOM;
             default: throw new IllegalArgumentException("Invalid screen time goal type: " + type);
         }

--- a/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
@@ -53,9 +53,7 @@ public class ProfileUpdateRequest {
     @Schema(description = "스크린 타임 목표 정보")
     public static class ScreenTimeGoal {
         @NotNull(message = "스크린 타임 목표 타입은 필수입니다")
-        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "12HOURS", "120", "240", "360", "480", "720", "CUSTOM"})
-
-
+        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "120", "240", "360", "480", "CUSTOM"})
         private String type;
 
         @Size(max = 100, message = "커스텀 스크린 타임 목표는 100자 이하여야 합니다")
@@ -74,7 +72,6 @@ public class ProfileUpdateRequest {
     public ScreenTimeGoalType getScreenTimeGoalType() {
         String type = screenTimeGoal.getType();
         switch (type) {
-
             case "2HOURS":
             case "120": return ScreenTimeGoalType.TWO_HOURS;
             case "4HOURS":
@@ -83,9 +80,6 @@ public class ProfileUpdateRequest {
             case "360": return ScreenTimeGoalType.SIX_HOURS;
             case "8HOURS":
             case "480": return ScreenTimeGoalType.EIGHT_HOURS;
-            case "12HOURS": 
-            case "720": return ScreenTimeGoalType.TWELVE_HOURS;
-
             case "CUSTOM": return ScreenTimeGoalType.CUSTOM;
             default: throw new IllegalArgumentException("Invalid screen time goal type: " + type);
         }

--- a/src/main/java/org/minu/dnd13th3backend/user/service/ProfileService.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/service/ProfileService.java
@@ -10,6 +10,7 @@ import org.minu.dnd13th3backend.user.entity.Profile;
 import org.minu.dnd13th3backend.user.entity.User;
 import org.minu.dnd13th3backend.user.repository.ProfileRepository;
 import org.minu.dnd13th3backend.user.repository.UserRepository;
+import org.minu.dnd13th3backend.user.type.ScreenTimeGoalType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,7 +42,7 @@ public class ProfileService {
         }
 
         Integer characterIndex = generateRandomCharacterIndex();
-        
+        validateScreenTimeGoalCustom(request.getScreenTimeGoalType(), request.getScreenTimeGoalCustom());
         Profile profile = Profile.builder()
                 .user(user)
                 .nickname(request.getNickname())
@@ -63,6 +64,7 @@ public class ProfileService {
 
         String nickname = request.getNickname() != null ? request.getNickname() : profile.getNickname();
         Integer characterIndex = request.getCharacterIndex() != null ? request.getCharacterIndex() : profile.getCharacterIndex();
+        validateScreenTimeGoalCustom(request.getScreenTimeGoalType(), request.getScreenTimeGoalCustom());
 
         profile.updateProfile(
                 nickname,
@@ -76,6 +78,19 @@ public class ProfileService {
     
     private Integer generateRandomCharacterIndex() {
         return random.nextInt(6) + 1;
+    }
+
+    private void validateScreenTimeGoalCustom(ScreenTimeGoalType type, String customValue) {
+        if (type == ScreenTimeGoalType.CUSTOM && customValue != null) {
+            try {
+                int customMinutes = Integer.parseInt(customValue);
+                if (customMinutes > 720) {
+                    throw new BusinessException(ErrorCode.SCREEN_TIME_GOAL_CUSTOM_LIMIT_EXCEEDED);
+                }
+            } catch (NumberFormatException e) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
     }
 
 }

--- a/src/main/java/org/minu/dnd13th3backend/user/type/ScreenTimeGoalType.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/type/ScreenTimeGoalType.java
@@ -8,7 +8,6 @@ public enum ScreenTimeGoalType {
     FOUR_HOURS("4HOURS", 240),
     SIX_HOURS("6HOURS", 360),
     EIGHT_HOURS("8HOURS", 480),
-    TWELVE_HOURS("12HOURS", 720),
     CUSTOM("CUSTOM", 0);
 
     private final String value;
@@ -43,8 +42,6 @@ public enum ScreenTimeGoalType {
                 return SIX_HOURS;
             case "480":
                 return EIGHT_HOURS;
-            case "12HOURS":
-                return TWELVE_HOURS;
             case "custom":
                 return CUSTOM;
             default:


### PR DESCRIPTION
## 작업 내용
목표타임에서 12시간(720분) 삭제 및 목표타임이 12시간을 넘으면 에러처리
```
 HTTP 400 Bad Request
  {
    "status": 400,
    "message": "커스텀 스크린 타임 목표는 12시간(720분)을 초과할 수 없습니다."
  }
```
## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enforces a maximum custom screen time of 12 hours (720 minutes) with a clear error message.
  - Rejects non-numeric custom screen time inputs with a bad request error.
  - Removes the 12-hour preset; available presets are now 2, 4, 6, and 8 hours, plus Custom.

- Documentation
  - API schema updated to reflect available screen time presets and the 12-hour custom limit.

- Bug Fixes
  - Improves validation to prevent invalid or out-of-range custom screen time values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->