### PR TITLE
fix: 스크린타임 갱신 로직 수정

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
+++ b/src/main/java/org/minu/dnd13th3backend/screentime/service/ScreenTimeService.java
@@ -45,11 +45,13 @@ public class ScreenTimeService {
             long minutesPassed = Duration.between(lastUpdate, now).toMinutes();
 
             if (minutesPassed > 0) {
+                int[] minutesToAdd = distributeTotalTime((int) minutesPassed, 4);
+
                 screenTime.updateScreenTime(
-                        screenTime.getInstagramMinutes() + (int) minutesPassed,
-                        screenTime.getYoutubeMinutes() + (int) minutesPassed,
-                        screenTime.getKakaotalkMinutes() + (int) minutesPassed,
-                        screenTime.getChromeMinutes() + (int) minutesPassed
+                        screenTime.getInstagramMinutes() + minutesToAdd[0],
+                        screenTime.getYoutubeMinutes() + minutesToAdd[1],
+                        screenTime.getKakaotalkMinutes() + minutesToAdd[2],
+                        screenTime.getChromeMinutes() + minutesToAdd[3]
                 );
             }
         } else {
@@ -107,18 +109,14 @@ public class ScreenTimeService {
     private int getGoalMinutes(Profile profile) {
         if (profile.getScreenTimeGoalType() == ScreenTimeGoalType.CUSTOM) {
             String customGoal = profile.getScreenTimeGoalCustom();
-
             if (customGoal == null || customGoal.trim().isEmpty()) {
                 return 240;
             }
-
             try {
                 String numericString = customGoal.replaceAll("[^\\d]", "");
-
                 if (numericString.isEmpty()) {
                     return 240;
                 }
-
                 return Integer.parseInt(numericString);
             } catch (NumberFormatException e) {
                 return 240;


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 스크린타임 갱신 api 호출 시 지난 시간 간격만큼 4개의 어플에 각각 더하는 로직을 4개의 어플에 값을 분배하여 총 스크린타임 값이 비정상적으로 크게 측정되지 않도록 수정하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screen time updates now distribute minutes intelligently across apps instead of adding the same amount to each, improving accuracy.
  * New screen time entries continue to initialize with a balanced distribution.
  * Daily goal behavior remains unchanged; defaults and parsing of custom goals are unaffected.
  * No changes to user settings or visible interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->