### PR TITLE
add: 프론트엔드 배포 주소 CORS 설정

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/config/WebConfig.java
+++ b/src/main/java/org/minu/dnd13th3backend/config/WebConfig.java
@@ -1,0 +1,22 @@
+package org.minu.dnd13th3backend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "https://dnd-13th-3-frontend.vercel.app"
+                )
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 프론트엔드의 로컬, 배포 주소에 따른 CORS 설정을 하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled global cross-origin requests for all API endpoints, allowing access from the local development domain and the deployed frontend.
  - Supports GET, POST, PUT, PATCH, DELETE, and OPTIONS, accepts any headers, and allows credentials.
  - Caches preflight responses for 1 hour to reduce latency.
  - Improves reliability and reduces cross-origin request failures across development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->