### PR TITLE
OPTIONS 메서드 요청 시 토큰 제거

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/auth/config/SecurityConfig.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.minu.dnd13th3backend.auth.filter.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod; // HttpMethod import 추가
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -17,7 +18,7 @@ public class SecurityConfig {
 
     @Autowired
     private CorsConfigurationSource corsConfigurationSource;
-    
+
     @Autowired
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
@@ -26,8 +27,9 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // STATELESS 권장
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/health").permitAll()
                         .requestMatchers("/oauth2/**", "/login/**", "/api/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 온보딩 시 OPTIONS 메서드 요청 시 토큰이 없어도 접근할 수 있도록 하여 CORS 에러를 해결할 수 있도록 수정하였습니다.

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Cross-origin preflight (OPTIONS) requests are now allowed across all endpoints, improving compatibility with browser-based clients.
- Bug Fixes
  - Resolved issues where cross-origin requests could fail due to blocked preflight checks.
- Chores
  - Updated security configuration to use stateless sessions, aligning authentication with token-based flows and reducing reliance on server-side session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->