### PR TITLE
fix: 로그인 시 oauth2 세션 값 다시 적용

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/auth/config/SecurityConfig.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/config/SecurityConfig.java
@@ -4,7 +4,7 @@ import org.minu.dnd13th3backend.auth.filter.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod; // HttpMethod import 추가
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -27,7 +27,7 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // STATELESS 권장
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/health").permitAll()


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 로그인 시 oauth2 세션 값 다시 적용

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced session handling: sessions are now created only when necessary, improving authentication reliability and compatibility with session-based flows.
* **Style**
  * Minor cleanup with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->