### PR TITLE
fix: 프로필 목표타임 custom 매핑 문자열 변경

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileRequest.java
@@ -48,11 +48,11 @@ public class ProfileRequest {
     @Schema(description = "스크린 타임 목표 정보")
     public static class ScreenTimeGoal {
         @NotNull(message = "스크린 타임 목표 타입은 필수입니다")
-        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "120", "240", "360", "480", "CUSTOM"})
+        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "120", "240", "360", "480", "custom"})
         private String type;
 
         @Size(max = 100, message = "커스텀 스크린 타임 목표는 100자 이하여야 합니다")
-        @Schema(description = "커스텀 스크린 타임 목표 (type이 CUSTOM일 때 필수)", example = "3시간", maxLength = 100)
+        @Schema(description = "커스텀 스크린 타임 목표 (type이 custom일 때 필수)", example = "3시간", maxLength = 100)
         private String custom;
     }
 
@@ -75,7 +75,7 @@ public class ProfileRequest {
             case "360": return ScreenTimeGoalType.SIX_HOURS;
             case "8HOURS":
             case "480": return ScreenTimeGoalType.EIGHT_HOURS;
-            case "CUSTOM": return ScreenTimeGoalType.CUSTOM;
+            case "custom": return ScreenTimeGoalType.CUSTOM;
             default: throw new IllegalArgumentException("Invalid screen time goal type: " + type);
         }
     }

--- a/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/minu/dnd13th3backend/user/dto/request/ProfileUpdateRequest.java
@@ -53,11 +53,11 @@ public class ProfileUpdateRequest {
     @Schema(description = "스크린 타임 목표 정보")
     public static class ScreenTimeGoal {
         @NotNull(message = "스크린 타임 목표 타입은 필수입니다")
-        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "120", "240", "360", "480", "CUSTOM"})
+        @Schema(description = "스크린 타임 목표 타입", example = "2HOURS", allowableValues = {"2HOURS", "4HOURS", "6HOURS", "8HOURS", "120", "240", "360", "480", "custom"})
         private String type;
 
         @Size(max = 100, message = "커스텀 스크린 타임 목표는 100자 이하여야 합니다")
-        @Schema(description = "커스텀 스크린 타임 목표 (type이 CUSTOM일 때 필수)", example = "3시간", maxLength = 100)
+        @Schema(description = "커스텀 스크린 타임 목표 (type이 custom일 때 필수)", example = "3시간", maxLength = 100)
         private String custom;
     }
 
@@ -80,7 +80,7 @@ public class ProfileUpdateRequest {
             case "360": return ScreenTimeGoalType.SIX_HOURS;
             case "8HOURS":
             case "480": return ScreenTimeGoalType.EIGHT_HOURS;
-            case "CUSTOM": return ScreenTimeGoalType.CUSTOM;
+            case "custom": return ScreenTimeGoalType.CUSTOM;
             default: throw new IllegalArgumentException("Invalid screen time goal type: " + type);
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the screen time goal type to use “custom” (lowercase) across profile create/update, ensuring consistent recognition and mapping.

* **Documentation**
  * Updated API docs to reflect “custom” (lowercase) in allowable values and field descriptions for screen time goals.

* **Chores**
  * Aligned request handling with the updated value format to prevent mismatches.

Note: Clients should use “custom” (lowercase) when specifying a custom screen time goal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->