### PR TITLE
feat: 네이티브 앱 OAuth2 로그인 분기 처리 구현

### DIFF
--- a/src/main/java/org/minu/dnd13th3backend/auth/config/SecurityConfig.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package org.minu.dnd13th3backend.auth.config;
 
 import org.minu.dnd13th3backend.auth.filter.JwtAuthenticationFilter;
+import org.minu.dnd13th3backend.auth.filter.NativeAppDetectionFilter;
+import org.minu.dnd13th3backend.auth.handler.OAuth2AuthenticationSuccessHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +24,12 @@ public class SecurityConfig {
     @Autowired
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @Autowired
+    private NativeAppDetectionFilter nativeAppDetectionFilter;
+
+    @Autowired
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -35,11 +43,13 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .defaultSuccessUrl("/api/auth/oauth2/success", true)
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
                         .failureUrl("/api/auth/oauth2/failure")
                 )
+                .addFilterBefore(nativeAppDetectionFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 }
+

--- a/src/main/java/org/minu/dnd13th3backend/auth/controller/AuthController.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/controller/AuthController.java
@@ -13,12 +13,8 @@ import org.minu.dnd13th3backend.auth.dto.TokenResponse;
 import org.minu.dnd13th3backend.auth.service.AuthService;
 import org.minu.dnd13th3backend.auth.service.RefreshTokenService;
 import org.minu.dnd13th3backend.auth.service.TokenBlacklistService;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.view.RedirectView;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -29,25 +25,6 @@ public class AuthController {
     private final AuthService authService;
     private final RefreshTokenService refreshTokenService;
     private final TokenBlacklistService tokenBlacklistService;
-    
-    @Value("${app.frontend.base-url}")
-    private String frontendBaseUrl;
-
-    @Operation(hidden = true)
-    @GetMapping("/oauth2/success")  
-    public RedirectView oauth2Success(@AuthenticationPrincipal OAuth2User oauth2User) {
-        TokenResponse tokenResponse = authService.processOAuth2Login(oauth2User);
-        
-        String frontendUrl = frontendBaseUrl + "/login/success" +
-                "?accessToken=" + tokenResponse.getAccessToken() +
-                "&refreshToken=" + tokenResponse.getRefreshToken() +
-
-                "&characterIndex=" + tokenResponse.getCharacterIndex() +
-                "&isNewUser=" + tokenResponse.getIsNewUser();
-
-        
-        return new RedirectView(frontendUrl);
-    }
 
     @Operation(hidden = true)
     @GetMapping("/oauth2/failure")
@@ -56,12 +33,12 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "JWT 토큰 갱신", 
+            summary = "JWT 토큰 갱신",
             description = "Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급받습니다."
     )
     @ApiResponses(value = {
             @ApiResponse(
-                    responseCode = "200", 
+                    responseCode = "200",
                     description = "토큰 갱신 성공",
                     content = @Content(
                             schema = @Schema(implementation = TokenResponse.class),
@@ -79,7 +56,7 @@ public class AuthController {
                     )
             ),
             @ApiResponse(
-                    responseCode = "401", 
+                    responseCode = "401",
                     description = "유효하지 않은 Refresh Token",
                     content = @Content(
                             examples = @ExampleObject(
@@ -88,7 +65,7 @@ public class AuthController {
                     )
             ),
             @ApiResponse(
-                    responseCode = "404", 
+                    responseCode = "404",
                     description = "사용자를 찾을 수 없음",
                     content = @Content(
                             examples = @ExampleObject(
@@ -100,7 +77,7 @@ public class AuthController {
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
             @Parameter(
-                    description = "Bearer {refreshToken} 형태의 Refresh Token", 
+                    description = "Bearer {refreshToken} 형태의 Refresh Token",
                     required = true,
                     example = "Bearer eyJhbGciOiJIUzUxMiJ9..."
             )
@@ -111,16 +88,16 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "로그아웃", 
+            summary = "로그아웃",
             description = "Access Token을 무효화하여 로그아웃합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(
-                    responseCode = "204", 
+                    responseCode = "204",
                     description = "로그아웃 성공"
             ),
             @ApiResponse(
-                    responseCode = "401", 
+                    responseCode = "401",
                     description = "유효하지 않은 토큰",
                     content = @Content(
                             examples = @ExampleObject(
@@ -132,18 +109,19 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
             @Parameter(
-                    description = "Bearer {accessToken} 형태의 Access Token", 
+                    description = "Bearer {accessToken} 형태의 Access Token",
                     required = true,
                     example = "Bearer eyJhbGciOiJIUzUxMiJ9..."
             )
             @RequestHeader("Authorization") String authHeader) {
-        
+
         String accessToken = authHeader.replace("Bearer ", "");
         String userId = authService.getUserIdFromToken(accessToken);
-        
+
         tokenBlacklistService.blacklistToken(accessToken);
         refreshTokenService.deleteRefreshToken(userId);
-        
+
         return ResponseEntity.noContent().build();
     }
 }
+

--- a/src/main/java/org/minu/dnd13th3backend/auth/filter/NativeAppDetectionFilter.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/filter/NativeAppDetectionFilter.java
@@ -1,0 +1,31 @@
+package org.minu.dnd13th3backend.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class NativeAppDetectionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (request.getRequestURI().startsWith("/oauth2/authorization/")) {
+            String isNativeApp = request.getParameter("is_native_app");
+            if ("true".equals(isNativeApp)) {
+                HttpSession session = request.getSession(true);
+                session.setAttribute("is_native_app", "true");
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/org/minu/dnd13th3backend/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/org/minu/dnd13th3backend/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,65 @@
+package org.minu.dnd13th3backend.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.minu.dnd13th3backend.auth.dto.TokenResponse;
+import org.minu.dnd13th3backend.auth.service.AuthService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final AuthService authService;
+
+    @Value("${app.frontend.base-url}")
+    private String frontendBaseUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
+        TokenResponse tokenResponse = authService.processOAuth2Login(oauth2User);
+
+        HttpSession session = request.getSession(false);
+        boolean isNativeApp = session != null && "true".equals(session.getAttribute("is_native_app"));
+
+        String targetUrl;
+
+        if (isNativeApp) {
+            targetUrl = UriComponentsBuilder.fromUriString("minu://login/success")
+                    .queryParam("accessToken", tokenResponse.getAccessToken())
+                    .queryParam("refreshToken", tokenResponse.getRefreshToken())
+                    .queryParam("characterIndex", tokenResponse.getCharacterIndex())
+                    .queryParam("isNewUser", tokenResponse.getIsNewUser())
+                    .build().toUriString();
+            log.info("Redirecting to native app: {}", targetUrl);
+        } else {
+            targetUrl = UriComponentsBuilder.fromUriString(frontendBaseUrl + "/login/success")
+                    .queryParam("accessToken", tokenResponse.getAccessToken())
+                    .queryParam("refreshToken", tokenResponse.getRefreshToken())
+                    .queryParam("characterIndex", tokenResponse.getCharacterIndex())
+                    .queryParam("isNewUser", tokenResponse.getIsNewUser())
+                    .build().toUriString();
+            log.info("Redirecting to web: {}", targetUrl);
+        }
+
+        if (session != null) {
+            session.removeAttribute("is_native_app");
+        }
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}
+


### PR DESCRIPTION
## 관련 이슈

## 작업 내용
- 앱패키징 구현함에 따라 로그인 시 앱과 웹을 분기처리하는 로직을 구현하였습니다.
- 웹 요청은 동일하며, 앱 요청 시 로그인 url 가장 뒷 부분에 ?is_native_app=true 만 추가해주시면 됩니다!

## 리뷰 요구사항(Optional)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Native app-aware OAuth2 login: detects native clients and redirects to the app (minu://) after sign-in; web users are redirected to the site. Redirect includes access/refresh tokens, character index, and new-user flag.
- Refactor
  - Consolidated OAuth2 success handling into a centralized mechanism for consistent redirects across platforms.
  - Removed the legacy OAuth2 success endpoint and static redirect configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->